### PR TITLE
Update WhatsApp buttons to new contact number

### DIFF
--- a/components/floating-whatsapp.tsx
+++ b/components/floating-whatsapp.tsx
@@ -4,7 +4,7 @@ import { MessageCircle } from 'lucide-react';
 export default function FloatingWhatsApp() {
   return (
     <a
-      href="https://wa.me/234000000000"
+      href="https://wa.me/2348104024943"
       className="fixed bottom-4 right-4 bg-accent text-ink p-3 rounded-full shadow-lg"
       aria-label="WhatsApp"
     >

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -57,7 +57,7 @@ export default function NavBar() {
             Try Ìlọ̀
           </Link>
           <Link
-            href="https://wa.me/234000000000"
+            href="https://wa.me/2348104024943"
             target="_blank"
             rel="noopener noreferrer"
             className={cn(buttonVariants({ variant: 'ghost' }), 'w-full text-center')}


### PR DESCRIPTION
## Summary
- point the floating WhatsApp button to the new phone number
- update the navbar WhatsApp CTA to use the same contact link

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c97c936a9083338edf13bb4f6cffcf