### PR TITLE
Revamp auth flows and refresh brand colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,11 @@ Marketing copy lives in `/content`. Update markdown, YAML, or JSON files and red
 
 Tailwind color tokens are defined in `tailwind.config.js` and backed by CSS variables:
 
-- `primary` – `#9C5C2E`
-- `secondary` – `#4A5B3F`
-- `accent` – `#D37E2C`
-- `ink` – `#2C221B`
-- `paper` – `#F4E7CD`
+- `primary` – `#0B6E4F`
+- `secondary` – `#F3A712`
+- `accent` – `#F05D23`
+- `ink` – `#1E1208`
+- `paper` – `#FDF6EB`
 
 ## Deploy to Vercel
 

--- a/app/(public)/auth/login/page.tsx
+++ b/app/(public)/auth/login/page.tsx
@@ -9,7 +9,7 @@ import { usePageEnter } from '@/lib/anim';
 import { supabaseBrowser } from '@/lib/supabaseBrowser';
 import { emailSchema, passwordSchema } from '@/lib/zodSchemas';
 import { motion } from 'framer-motion';
-import { LogIn } from 'lucide-react';
+import { CheckCircle2, Clock3, Eye, EyeOff, Lock, LogIn, Mail, ShieldCheck, UsersRound } from 'lucide-react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { type FormEvent, useMemo, useState } from 'react';
@@ -71,6 +71,33 @@ export default function LoginPage() {
       { id: 'password' as const, label: 'Password' },
     ];
   }, []);
+
+  const highlightItems = useMemo(
+    () => [
+      {
+        title: 'Kid-safe links',
+        description: 'Magic links expire quickly so curious kids stay protected.',
+        icon: <ShieldCheck className="h-6 w-6" aria-hidden="true" />,
+      },
+      {
+        title: 'Fast access',
+        description: 'Email arrives within a minute and works on any trusted device.',
+        icon: <Clock3 className="h-6 w-6" aria-hidden="true" />,
+      },
+      {
+        title: 'Guardian controls',
+        description: 'Manage passwords and child profiles from your family dashboard.',
+        icon: <UsersRound className="h-6 w-6" aria-hidden="true" />,
+      },
+    ],
+    [],
+  );
+
+  const showMagicSuccess = magicTouched && !magicError && magicEmail.length > 0;
+  const showPasswordEmailSuccess =
+    passwordTouched.email && !passwordErrors.email && passwordEmail.length > 0;
+  const showPasswordValueSuccess =
+    passwordTouched.password && !passwordErrors.password && passwordValue.length > 0;
 
   const handleMagicSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -163,157 +190,257 @@ export default function LoginPage() {
   };
 
   return (
-    <motion.div {...motionProps} className="mx-auto flex w-full max-w-3xl flex-col gap-8">
-      <header className="space-y-2">
-        <h1 className="text-4xl font-serif c-on-paper">Welcome back</h1>
-        <p className="text-lg leading-relaxed c-on-paper">
-          Choose the simplest way to sign in. We use secure magic links and passwords that kids can’t guess.
-        </p>
-      </header>
-      <AuthCard
-        title="Sign in to Ìlọ̀"
-        description="Pick a sign-in option that works best for your family."
-        icon={<LogIn className="h-7 w-7" aria-hidden="true" />}
-        eyebrow="Safe for guardians"
-      >
-        <div className="space-y-6">
-          {tabs.length > 1 ? (
-            <div role="tablist" aria-label="Sign in options" className="flex flex-wrap gap-3">
-              {tabs.map((tab) => {
-                const isActive = activeTab === tab.id;
-                return (
-                  <button
-                    key={tab.id}
-                    type="button"
-                    role="tab"
-                    aria-selected={isActive}
-                    onClick={() => setActiveTab(tab.id)}
-                    className={`rounded-full px-4 py-2 text-sm font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-surface)] ${
-                      isActive
-                        ? 'bg-primary c-on-primary shadow-sm'
-                        : 'bg-surface/60 c-on-surface border border-[color:var(--color-on-surface)]/20'
-                    }`}
-                  >
-                    {tab.label}
-                  </button>
-                );
-              })}
-            </div>
-          ) : null}
-
-          {activeTab === 'magic' ? (
-            <form className="space-y-4" onSubmit={handleMagicSubmit} noValidate>
-              {magicNotice ? <Alert variant={magicNotice.variant}>{magicNotice.message}</Alert> : null}
-              <Input
-                label="Email address"
-                type="email"
-                value={magicEmail}
-                onChange={(event) => {
-                  const nextValue = event.target.value;
-                  setMagicEmail(nextValue);
-                  if (magicTouched) {
-                    setMagicError(getEmailError(nextValue));
-                  }
-                  if (magicNotice) {
-                    setMagicNotice(null);
-                  }
-                }}
-                onBlur={() => {
-                  setMagicTouched(true);
-                  setMagicError(getEmailError(magicEmail));
-                }}
-                helperText="We’ll send you a magic link so you don’t need to remember a password."
-                errorText={magicError ?? undefined}
-                autoComplete="email"
-                required
-              />
-              <Button type="submit" disabled={magicLoading} className="w-full">
-                {magicLoading ? 'Sending link…' : 'Send magic link'}
-              </Button>
-            </form>
-          ) : null}
-
-          {passwordAuthEnabled && activeTab === 'password' ? (
-            <form className="space-y-4" onSubmit={handlePasswordSubmit} noValidate>
-              {passwordNotice ? <Alert variant={passwordNotice.variant}>{passwordNotice.message}</Alert> : null}
-              <Input
-                label="Email address"
-                type="email"
-                value={passwordEmail}
-                onChange={(event) => {
-                  const nextValue = event.target.value;
-                  setPasswordEmail(nextValue);
-                  if (passwordTouched.email) {
-                    setPasswordErrors((prev) => ({ ...prev, email: getEmailError(nextValue) }));
-                  }
-                  if (passwordNotice) {
-                    setPasswordNotice(null);
-                  }
-                }}
-                onBlur={() => {
-                  setPasswordTouched((prev) => ({ ...prev, email: true }));
-                  setPasswordErrors((prev) => ({ ...prev, email: getEmailError(passwordEmail) }));
-                }}
-                helperText="Enter the email you used when creating your guardian account."
-                errorText={passwordErrors.email ?? undefined}
-                autoComplete="email"
-                required
-              />
-              <Input
-                label="Password"
-                type={showPassword ? 'text' : 'password'}
-                value={passwordValue}
-                onChange={(event) => {
-                  const nextValue = event.target.value;
-                  setPasswordValue(nextValue);
-                  if (passwordTouched.password) {
-                    setPasswordErrors((prev) => ({ ...prev, password: getPasswordError(nextValue) }));
-                  }
-                  if (passwordNotice) {
-                    setPasswordNotice(null);
-                  }
-                }}
-                onBlur={() => {
-                  setPasswordTouched((prev) => ({ ...prev, password: true }));
-                  setPasswordErrors((prev) => ({ ...prev, password: getPasswordError(passwordValue) }));
-                }}
-                helperText="Keep your password private so only grown-ups can sign in."
-                errorText={passwordErrors.password ?? undefined}
-                autoComplete="current-password"
-                required
-                trailingAccessory={
-                  <button
-                    type="button"
-                    onClick={() => setShowPassword((prev) => !prev)}
-                    className="rounded-full bg-[color:var(--color-on-surface)]/10 px-3 py-2 text-sm font-semibold c-on-surface transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-surface)]"
-                    aria-pressed={showPassword}
-                  >
-                    {showPassword ? 'Hide' : 'Show'}
-                  </button>
-                }
-              />
-              <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                <Link href="/help" className="text-sm font-semibold underline-offset-4 c-on-surface hover:underline">
-                  Forgot password?
-                </Link>
-                <Button type="submit" disabled={passwordLoading} className="w-full sm:w-auto">
-                  {passwordLoading ? 'Signing in…' : 'Sign in'}
-                </Button>
-              </div>
-            </form>
-          ) : null}
-
-          <Divider>New to Ìlọ̀?</Divider>
-          <div className="flex flex-col gap-3 rounded-2xl bg-[color:var(--color-on-surface)]/5 p-4 sm:flex-row sm:items-center sm:justify-between">
-            <p className="text-base leading-relaxed c-on-surface">
-              Guardians can create an account to add child profiles and track progress.
-            </p>
-            <Button href="/auth/signup" variant="secondary" className="w-full sm:w-auto">
-              Create an account
-            </Button>
-          </div>
+    <motion.div
+      {...motionProps}
+      className="mx-auto flex w-full max-w-6xl flex-col gap-12 px-4 py-10 sm:px-6 lg:px-8"
+    >
+      <header className="space-y-4 text-center sm:text-left">
+        <div className="mx-auto inline-flex items-center gap-2 rounded-full bg-[color:var(--color-primary)]/10 px-4 py-2 text-sm font-semibold text-[color:var(--color-primary)] sm:mx-0">
+          <LogIn className="h-4 w-4" aria-hidden="true" />
+          <span>Guardian protected sign-in</span>
         </div>
-      </AuthCard>
+        <div className="space-y-2">
+          <h1 className="text-4xl font-serif c-on-paper sm:text-5xl">Welcome back</h1>
+          <p className="text-lg leading-relaxed c-on-paper opacity-80 sm:max-w-2xl">
+            Choose the sign-in flow that fits your day. We keep your learner profiles safe behind
+            magic links and strong passwords.
+          </p>
+        </div>
+      </header>
+      <div className="grid gap-8 lg:grid-cols-[minmax(0,7fr)_minmax(0,5fr)]">
+        <AuthCard
+          title="Sign in to Ìlọ̀"
+          description="Securely access your family dashboard and keep every child’s progress in one joyful place."
+          icon={<LogIn className="h-7 w-7" aria-hidden="true" />}
+          eyebrow="Family access"
+          headerTone="primary"
+        >
+          <div className="space-y-6">
+            <p className="rounded-2xl border border-[color:var(--color-primary)]/15 bg-[color:var(--color-primary)]/5 p-4 text-base leading-relaxed text-[color:var(--color-on-surface)]">
+              Use the email you registered with Ìlọ̀. Magic links stay active for 15 minutes so only
+              trusted grown-ups can join your learners.
+            </p>
+            {tabs.length > 1 ? (
+              <div
+                role="tablist"
+                aria-label="Sign in options"
+                className="flex flex-wrap gap-3 rounded-2xl bg-[color:var(--color-on-surface)]/5 p-2"
+              >
+                {tabs.map((tab) => {
+                  const isActive = activeTab === tab.id;
+                  return (
+                    <button
+                      key={tab.id}
+                      type="button"
+                      role="tab"
+                      aria-selected={isActive}
+                      onClick={() => setActiveTab(tab.id)}
+                      className={`rounded-full px-4 py-2 text-sm font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-surface)] ${
+                        isActive
+                          ? 'bg-primary c-on-primary shadow-sm'
+                          : 'border border-[color:var(--color-on-surface)]/15 bg-[color:var(--color-on-surface)]/5 text-[color:var(--color-on-surface)] hover:bg-[color:var(--color-on-surface)]/10'
+                      }`}
+                    >
+                      {tab.label}
+                    </button>
+                  );
+                })}
+              </div>
+            ) : null}
+
+            {activeTab === 'magic' ? (
+              <form className="space-y-5" onSubmit={handleMagicSubmit} noValidate>
+                {magicNotice ? <Alert variant={magicNotice.variant}>{magicNotice.message}</Alert> : null}
+                <Input
+                  label="Email address"
+                  type="email"
+                  value={magicEmail}
+                  leadingIcon={<Mail className="h-5 w-5 text-[color:var(--color-primary)]" aria-hidden="true" />}
+                  trailingIcon={
+                    showMagicSuccess ? (
+                      <CheckCircle2 className="h-5 w-5 text-[color:var(--color-primary)]" aria-hidden="true" />
+                    ) : undefined
+                  }
+                  onChange={(event) => {
+                    const nextValue = event.target.value;
+                    setMagicEmail(nextValue);
+                    if (magicTouched) {
+                      setMagicError(getEmailError(nextValue));
+                    }
+                    if (magicNotice) {
+                      setMagicNotice(null);
+                    }
+                  }}
+                  onBlur={() => {
+                    setMagicTouched(true);
+                    setMagicError(getEmailError(magicEmail));
+                  }}
+                  helperText="We’ll send a one-time link that expires in 15 minutes."
+                  errorText={magicError ?? undefined}
+                  autoComplete="email"
+                  required
+                />
+                <Button type="submit" disabled={magicLoading} className="w-full">
+                  {magicLoading ? 'Sending link…' : 'Send safe magic link'}
+                </Button>
+                <p className="text-sm text-[color:var(--color-on-surface)]/70">
+                  Look for an email from <span className="font-semibold text-primary">hello@ilo.school</span>.
+                  Open it on the device you want to use.
+                </p>
+              </form>
+            ) : null}
+
+            {passwordAuthEnabled && activeTab === 'password' ? (
+              <form className="space-y-5" onSubmit={handlePasswordSubmit} noValidate>
+                {passwordNotice ? <Alert variant={passwordNotice.variant}>{passwordNotice.message}</Alert> : null}
+                <Input
+                  label="Email address"
+                  type="email"
+                  value={passwordEmail}
+                  leadingIcon={<Mail className="h-5 w-5 text-[color:var(--color-primary)]" aria-hidden="true" />}
+                  trailingIcon={
+                    showPasswordEmailSuccess ? (
+                      <CheckCircle2 className="h-5 w-5 text-[color:var(--color-primary)]" aria-hidden="true" />
+                    ) : undefined
+                  }
+                  onChange={(event) => {
+                    const nextValue = event.target.value;
+                    setPasswordEmail(nextValue);
+                    if (passwordTouched.email) {
+                      setPasswordErrors((prev) => ({ ...prev, email: getEmailError(nextValue) }));
+                    }
+                    if (passwordNotice) {
+                      setPasswordNotice(null);
+                    }
+                  }}
+                  onBlur={() => {
+                    setPasswordTouched((prev) => ({ ...prev, email: true }));
+                    setPasswordErrors((prev) => ({ ...prev, email: getEmailError(passwordEmail) }));
+                  }}
+                  helperText="Use the email you used when creating your guardian account."
+                  errorText={passwordErrors.email ?? undefined}
+                  autoComplete="email"
+                  required
+                />
+                <Input
+                  label="Password"
+                  type={showPassword ? 'text' : 'password'}
+                  value={passwordValue}
+                  leadingIcon={<Lock className="h-5 w-5 text-[color:var(--color-primary)]" aria-hidden="true" />}
+                  trailingIcon={
+                    showPasswordValueSuccess ? (
+                      <CheckCircle2 className="h-5 w-5 text-[color:var(--color-primary)]" aria-hidden="true" />
+                    ) : undefined
+                  }
+                  onChange={(event) => {
+                    const nextValue = event.target.value;
+                    setPasswordValue(nextValue);
+                    if (passwordTouched.password) {
+                      setPasswordErrors((prev) => ({ ...prev, password: getPasswordError(nextValue) }));
+                    }
+                    if (passwordNotice) {
+                      setPasswordNotice(null);
+                    }
+                  }}
+                  onBlur={() => {
+                    setPasswordTouched((prev) => ({ ...prev, password: true }));
+                    setPasswordErrors((prev) => ({ ...prev, password: getPasswordError(passwordValue) }));
+                  }}
+                  helperText="Include upper and lowercase letters plus a number."
+                  errorText={passwordErrors.password ?? undefined}
+                  autoComplete="current-password"
+                  required
+                  trailingAccessory={
+                    <button
+                      type="button"
+                      onClick={() => setShowPassword((prev) => !prev)}
+                      className="inline-flex items-center gap-2 rounded-full bg-[color:var(--color-primary)]/10 px-3 py-2 text-sm font-semibold text-[color:var(--color-on-surface)] transition hover:bg-[color:var(--color-primary)]/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-surface)]"
+                      aria-pressed={showPassword}
+                      aria-label={showPassword ? 'Hide password' : 'Show password'}
+                    >
+                      {showPassword ? (
+                        <EyeOff className="h-4 w-4" aria-hidden="true" />
+                      ) : (
+                        <Eye className="h-4 w-4" aria-hidden="true" />
+                      )}
+                      <span className="text-sm font-semibold">{showPassword ? 'Hide' : 'Show'}</span>
+                    </button>
+                  }
+                />
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                  <Link
+                    href="/help"
+                    className="text-sm font-semibold underline-offset-4 text-[color:var(--color-on-surface)] hover:underline"
+                  >
+                    Forgot password?
+                  </Link>
+                  <Button type="submit" disabled={passwordLoading} className="w-full sm:w-auto">
+                    {passwordLoading ? 'Signing in…' : 'Sign in securely'}
+                  </Button>
+                </div>
+              </form>
+            ) : null}
+
+            <Divider>Need an account?</Divider>
+            <div className="flex flex-col gap-4 rounded-2xl border border-[color:var(--color-primary)]/15 bg-[color:var(--color-primary)]/5 p-5 sm:flex-row sm:items-center sm:justify-between">
+              <p className="text-base leading-relaxed text-[color:var(--color-on-surface)]">
+                Guardians can create an account to add child profiles and track joyful progress.
+              </p>
+              <Button href="/auth/signup" variant="secondary" className="w-full sm:w-auto">
+                Create an account
+              </Button>
+            </div>
+          </div>
+        </AuthCard>
+        <section className="space-y-6 rounded-3xl bg-[color:var(--color-surface)]/70 p-6 ring-1 ring-[color:var(--color-on-surface)]/10 backdrop-blur-sm">
+          <h2 className="text-2xl font-serif leading-tight text-[color:var(--color-on-surface)]">
+            Why families trust Ìlọ̀
+          </h2>
+          <p className="text-base leading-relaxed text-[color:var(--color-on-surface)]/80">
+            Every guardian account comes with tools to keep little learners safe while celebrating their wins.
+          </p>
+          <ul className="space-y-4">
+            {highlightItems.map((item) => (
+              <li
+                key={item.title}
+                className="flex gap-3 rounded-2xl border border-[color:var(--color-on-surface)]/10 bg-[color:var(--color-on-surface)]/5 p-4"
+              >
+                <span className="flex h-12 w-12 items-center justify-center rounded-2xl bg-[color:var(--color-primary)]/10 text-[color:var(--color-primary)]">
+                  {item.icon}
+                </span>
+                <div className="space-y-1">
+                  <p className="text-lg font-semibold text-[color:var(--color-on-surface)]">{item.title}</p>
+                  <p className="text-base leading-relaxed text-[color:var(--color-on-surface)]/80">
+                    {item.description}
+                  </p>
+                </div>
+              </li>
+            ))}
+          </ul>
+          <div className="space-y-3 rounded-2xl bg-[color:var(--color-primary)]/10 p-5 text-[color:var(--color-on-surface)]">
+            <p className="text-base leading-relaxed">
+              Need a hand right now? Visit our{' '}
+              <Link
+                href="/help"
+                className="font-semibold text-primary underline-offset-4 hover:underline"
+              >
+                help center
+              </Link>{' '}
+              or email{' '}
+              <a
+                href="mailto:hello@ilo.school"
+                className="font-semibold text-primary underline-offset-4 hover:underline"
+              >
+                hello@ilo.school
+              </a>
+              .
+            </p>
+            <p className="text-sm text-[color:var(--color-on-surface)]/70">
+              We respond within one business day and love hearing from guardians.
+            </p>
+          </div>
+        </section>
+      </div>
     </motion.div>
   );
 }

--- a/app/(public)/auth/signup/page.tsx
+++ b/app/(public)/auth/signup/page.tsx
@@ -9,8 +9,20 @@ import { Select } from '@/components/ui/Select';
 import { usePageEnter } from '@/lib/anim';
 import { guardianSignupSchema } from '@/lib/zodSchemas';
 import { motion } from 'framer-motion';
-import { Sparkles } from 'lucide-react';
+import {
+  BookOpenCheck,
+  CheckCircle2,
+  Eye,
+  EyeOff,
+  Globe,
+  Heart,
+  Lock,
+  Mail,
+  Sparkles,
+  User,
+} from 'lucide-react';
 import { type FormEvent, useMemo, useState } from 'react';
+import Link from 'next/link';
 
 const passwordAuthEnabled = process.env.NEXT_PUBLIC_SUPABASE_PASSWORD_AUTH === 'true';
 
@@ -86,12 +98,77 @@ export default function SignupPage() {
   const [displayName, setDisplayName] = useState('');
   const [country, setCountry] = useState('');
   const [password, setPassword] = useState('');
+  const [updatesOptIn, setUpdatesOptIn] = useState(false);
+  const [showPassword, setShowPassword] = useState(false);
   const [touched, setTouched] = useState({ email: false, displayName: false, country: false, password: false });
   const [errors, setErrors] = useState<SignupErrors>({ email: null, displayName: null, country: null, password: null });
   const [notice, setNotice] = useState<Notice>(null);
   const [loading, setLoading] = useState(false);
 
   const countryOptions = useMemo(() => COUNTRIES.map((value) => ({ value, label: value })), []);
+
+  const stepItems = useMemo(
+    () => [
+      {
+        title: 'Guardian details',
+        description: 'Share your name and email so we know who to send magic links to.',
+        status: 'current' as const,
+      },
+      {
+        title: 'Confirm your email',
+        description: 'Tap the Yoruba link in your inbox to prove it’s really you.',
+        status: 'upcoming' as const,
+      },
+      {
+        title: 'Add child profiles',
+        description: 'Create joyful spaces for each learner after sign-up.',
+        status: 'upcoming' as const,
+      },
+    ],
+    [],
+  );
+
+  const highlightItems = useMemo(
+    () => [
+      {
+        title: 'Culture-rich stories',
+        description: 'Unlock songs, folktales, and call-and-response activities made for Yoruba learners.',
+        icon: <Sparkles className="h-6 w-6" aria-hidden="true" />,
+      },
+      {
+        title: 'Family-friendly controls',
+        description: 'Switch between child profiles without sharing devices or passwords.',
+        icon: <Heart className="h-6 w-6" aria-hidden="true" />,
+      },
+      {
+        title: 'Progress at a glance',
+        description: 'See streaks, stars, and badges so you can celebrate every milestone.',
+        icon: <BookOpenCheck className="h-6 w-6" aria-hidden="true" />,
+      },
+    ],
+    [],
+  );
+
+  const showEmailSuccess = touched.email && !errors.email && email.length > 0;
+  const showDisplayNameSuccess = touched.displayName && !errors.displayName && displayName.length > 0;
+  const showCountrySuccess = touched.country && !errors.country && Boolean(country);
+  const showPasswordSuccess =
+    passwordAuthEnabled && touched.password && !errors.password && password.length > 0;
+
+  const emailHelper = showEmailSuccess
+    ? 'Great! We’ll send confirmation to this address.'
+    : 'We’ll use this email to send you a safe magic link.';
+  const nameHelper = showDisplayNameSuccess
+    ? 'Thanks! Kids will see this name in their dashboard.'
+    : 'This helps kids recognise who is guiding them.';
+  const countryHelper = showCountrySuccess
+    ? `Nice! We’ll tailor stories for learners in ${country}.`
+    : 'We use this to tailor stories and time zones.';
+  const passwordHelper = passwordAuthEnabled
+    ? showPasswordSuccess
+      ? 'Perfect! Keep this password private.'
+      : 'Use at least 8 characters with a mix of letters and numbers.'
+    : undefined;
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -124,6 +201,7 @@ export default function SignupPage() {
         displayName,
         country: country || undefined,
         password: passwordAuthEnabled ? password : undefined,
+        updatesOptIn,
       };
       const parsed = guardianSignupSchema.safeParse(payload);
       if (!parsed.success) {
@@ -163,128 +241,266 @@ export default function SignupPage() {
   };
 
   return (
-    <motion.div {...motionProps} className="mx-auto flex w-full max-w-3xl flex-col gap-8">
-      <header className="space-y-2">
-        <h1 className="text-4xl font-serif c-on-paper">Create your account</h1>
-        <p className="text-lg leading-relaxed c-on-paper">
-          Grown-ups sign up first so you can add playful child profiles and keep everyone safe.
-        </p>
-      </header>
-      <AuthCard
-        title="Guardian sign up"
-        description="We’ll send a link to verify your email and keep little learners protected."
-        icon={<Sparkles className="h-7 w-7" aria-hidden="true" />}
-        eyebrow="Step 1"
-      >
-        <form className="space-y-5" onSubmit={handleSubmit} noValidate>
-          {notice ? <Alert variant={notice.variant}>{notice.message}</Alert> : null}
-          <Input
-            label="Email address"
-            type="email"
-            value={email}
-            onChange={(event) => {
-              const nextValue = event.target.value;
-              setEmail(nextValue);
-              if (touched.email) {
-                setErrors((prev) => ({ ...prev, email: getEmailError(nextValue) }));
-              }
-              if (notice) {
-                setNotice(null);
-              }
-            }}
-            onBlur={() => {
-              setTouched((prev) => ({ ...prev, email: true }));
-              setErrors((prev) => ({ ...prev, email: getEmailError(email) }));
-            }}
-            helperText="We’ll use this email to send you a safe magic link."
-            errorText={errors.email ?? undefined}
-            autoComplete="email"
-            required
-          />
-          <Input
-            label="Display name"
-            value={displayName}
-            onChange={(event) => {
-              const nextValue = event.target.value;
-              setDisplayName(nextValue);
-              if (touched.displayName) {
-                setErrors((prev) => ({ ...prev, displayName: getDisplayNameError(nextValue) }));
-              }
-            }}
-            onBlur={() => {
-              setTouched((prev) => ({ ...prev, displayName: true }));
-              setErrors((prev) => ({ ...prev, displayName: getDisplayNameError(displayName) }));
-            }}
-            helperText="This helps kids recognise who is guiding them."
-            errorText={errors.displayName ?? undefined}
-            autoComplete="name"
-            required
-          />
-          <Select
-            label="Country"
-            value={country}
-            onChange={(event) => {
-              const nextValue = event.target.value;
-              setCountry(nextValue);
-              if (touched.country) {
-                setErrors((prev) => ({ ...prev, country: getCountryError(nextValue) }));
-              }
-            }}
-            onBlur={() => {
-              setTouched((prev) => ({ ...prev, country: true }));
-              setErrors((prev) => ({ ...prev, country: getCountryError(country) }));
-            }}
-            helperText="We use this to tailor stories and time zones."
-            errorText={errors.country ?? undefined}
-          >
-            <option value="">Select a country</option>
-            {countryOptions.map((option) => (
-              <option key={option.value} value={option.value}>
-                {option.label}
-              </option>
-            ))}
-          </Select>
-          {passwordAuthEnabled ? (
-            <Input
-              label="Create a password"
-              type="password"
-              value={password}
-              onChange={(event) => {
-                const nextValue = event.target.value;
-                setPassword(nextValue);
-                if (touched.password) {
-                  setErrors((prev) => ({ ...prev, password: getPasswordError(nextValue) }));
-                }
-              }}
-              onBlur={() => {
-                setTouched((prev) => ({ ...prev, password: true }));
-                setErrors((prev) => ({ ...prev, password: getPasswordError(password) }));
-              }}
-              helperText="Use at least 8 characters with a mix of letters and numbers."
-              errorText={errors.password ?? undefined}
-              autoComplete="new-password"
-            />
-          ) : null}
-          <Button type="submit" disabled={loading} className="w-full">
-            {loading ? 'Creating account…' : 'Create account'}
-          </Button>
-        </form>
-        <Divider>Next steps</Divider>
-        <div className="space-y-4 rounded-2xl bg-[color:var(--color-on-surface)]/5 p-5">
-          <p className="text-base leading-relaxed c-on-surface">
-            After you confirm the magic link, you can add child profiles so each kid has their own joyful space.
+    <motion.div
+      {...motionProps}
+      className="mx-auto flex w-full max-w-6xl flex-col gap-12 px-4 py-10 sm:px-6 lg:px-8"
+    >
+      <header className="space-y-4 text-center sm:text-left">
+        <div className="mx-auto inline-flex items-center gap-2 rounded-full bg-[color:var(--color-accent)]/15 px-4 py-2 text-sm font-semibold text-[color:var(--color-accent)] sm:mx-0">
+          <Sparkles className="h-4 w-4" aria-hidden="true" />
+          <span>Start your guardian journey</span>
+        </div>
+        <div className="space-y-2">
+          <h1 className="text-4xl font-serif c-on-paper sm:text-5xl">Create your account</h1>
+          <p className="text-lg leading-relaxed c-on-paper opacity-80 sm:max-w-2xl">
+            Grown-ups sign up first so you can add playful child profiles and keep everyone safe.
           </p>
-          <Button href="/kids" variant="secondary" className="w-full sm:w-auto">
-            Add a child profile
-          </Button>
         </div>
-        <div className="flex flex-col gap-3 pt-4 sm:flex-row sm:items-center sm:justify-between">
-          <p className="text-base c-on-surface">Already have an account?</p>
-          <Button href="/auth/login" variant="ghost" className="w-full sm:w-auto">
-            Log in instead
-          </Button>
-        </div>
-      </AuthCard>
+      </header>
+      <div className="grid gap-8 lg:grid-cols-[minmax(0,7fr)_minmax(0,5fr)]">
+        <AuthCard
+          title="Guardian sign up"
+          description="We’ll send a link to verify your email and keep little learners protected."
+          icon={<Sparkles className="h-7 w-7" aria-hidden="true" />}
+          eyebrow="Step 1"
+          headerTone="accent"
+        >
+          <div className="space-y-6">
+            <ol className="grid gap-4 rounded-2xl border border-[color:var(--color-accent)]/20 bg-[color:var(--color-accent)]/10 p-4 sm:grid-cols-3">
+              {stepItems.map((step, index) => {
+                const isCurrent = step.status === 'current';
+                return (
+                  <li
+                    key={step.title}
+                    className={`space-y-1 rounded-2xl p-3 text-[color:var(--color-on-surface)] ${
+                      isCurrent ? 'bg-[color:var(--color-surface)] shadow-sm' : 'bg-transparent'
+                    }`}
+                  >
+                    <span className="text-xs font-semibold uppercase tracking-wide text-[color:var(--color-primary)]">
+                      Step {index + 1}
+                    </span>
+                    <p className="text-base font-semibold">{step.title}</p>
+                    <p className="text-sm leading-relaxed text-[color:var(--color-on-surface)]/80">
+                      {step.description}
+                    </p>
+                  </li>
+                );
+              })}
+            </ol>
+            <form className="space-y-5" onSubmit={handleSubmit} noValidate>
+              {notice ? <Alert variant={notice.variant}>{notice.message}</Alert> : null}
+              <Input
+                label="Email address"
+                type="email"
+                value={email}
+                leadingIcon={<Mail className="h-5 w-5 text-[color:var(--color-primary)]" aria-hidden="true" />}
+                trailingIcon={
+                  showEmailSuccess ? (
+                    <CheckCircle2 className="h-5 w-5 text-[color:var(--color-primary)]" aria-hidden="true" />
+                  ) : undefined
+                }
+                onChange={(event) => {
+                  const nextValue = event.target.value;
+                  setEmail(nextValue);
+                  if (touched.email) {
+                    setErrors((prev) => ({ ...prev, email: getEmailError(nextValue) }));
+                  }
+                  if (notice) {
+                    setNotice(null);
+                  }
+                }}
+                onBlur={() => {
+                  setTouched((prev) => ({ ...prev, email: true }));
+                  setErrors((prev) => ({ ...prev, email: getEmailError(email) }));
+                }}
+                helperText={emailHelper}
+                errorText={errors.email ?? undefined}
+                autoComplete="email"
+                required
+              />
+              <Input
+                label="Display name"
+                value={displayName}
+                leadingIcon={<User className="h-5 w-5 text-[color:var(--color-primary)]" aria-hidden="true" />}
+                trailingIcon={
+                  showDisplayNameSuccess ? (
+                    <CheckCircle2 className="h-5 w-5 text-[color:var(--color-primary)]" aria-hidden="true" />
+                  ) : undefined
+                }
+                onChange={(event) => {
+                  const nextValue = event.target.value;
+                  setDisplayName(nextValue);
+                  if (touched.displayName) {
+                    setErrors((prev) => ({ ...prev, displayName: getDisplayNameError(nextValue) }));
+                  }
+                  if (notice) {
+                    setNotice(null);
+                  }
+                }}
+                onBlur={() => {
+                  setTouched((prev) => ({ ...prev, displayName: true }));
+                  setErrors((prev) => ({ ...prev, displayName: getDisplayNameError(displayName) }));
+                }}
+                helperText={nameHelper}
+                errorText={errors.displayName ?? undefined}
+                autoComplete="name"
+                required
+              />
+              <Select
+                label="Country"
+                value={country}
+                leadingIcon={<Globe className="h-5 w-5 text-[color:var(--color-primary)]" aria-hidden="true" />}
+                onChange={(event) => {
+                  const nextValue = event.target.value;
+                  setCountry(nextValue);
+                  if (touched.country) {
+                    setErrors((prev) => ({ ...prev, country: getCountryError(nextValue) }));
+                  }
+                  if (notice) {
+                    setNotice(null);
+                  }
+                }}
+                onBlur={() => {
+                  setTouched((prev) => ({ ...prev, country: true }));
+                  setErrors((prev) => ({ ...prev, country: getCountryError(country) }));
+                }}
+                helperText={countryHelper}
+                errorText={errors.country ?? undefined}
+              >
+                <option value="">Select a country</option>
+                {countryOptions.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </Select>
+              {passwordAuthEnabled ? (
+                <Input
+                  label="Create a password"
+                  type={showPassword ? 'text' : 'password'}
+                  value={password}
+                  leadingIcon={<Lock className="h-5 w-5 text-[color:var(--color-primary)]" aria-hidden="true" />}
+                  trailingIcon={
+                    showPasswordSuccess ? (
+                      <CheckCircle2 className="h-5 w-5 text-[color:var(--color-primary)]" aria-hidden="true" />
+                    ) : undefined
+                  }
+                  onChange={(event) => {
+                    const nextValue = event.target.value;
+                    setPassword(nextValue);
+                    if (touched.password) {
+                      setErrors((prev) => ({ ...prev, password: getPasswordError(nextValue) }));
+                    }
+                    if (notice) {
+                      setNotice(null);
+                    }
+                  }}
+                  onBlur={() => {
+                    setTouched((prev) => ({ ...prev, password: true }));
+                    setErrors((prev) => ({ ...prev, password: getPasswordError(password) }));
+                  }}
+                  helperText={passwordHelper}
+                  errorText={errors.password ?? undefined}
+                  autoComplete="new-password"
+                  trailingAccessory={
+                    <button
+                      type="button"
+                      onClick={() => setShowPassword((prev) => !prev)}
+                      className="inline-flex items-center gap-2 rounded-full bg-[color:var(--color-primary)]/10 px-3 py-2 text-sm font-semibold text-[color:var(--color-on-surface)] transition hover:bg-[color:var(--color-primary)]/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-surface)]"
+                      aria-pressed={showPassword}
+                      aria-label={showPassword ? 'Hide password' : 'Show password'}
+                    >
+                      {showPassword ? (
+                        <EyeOff className="h-4 w-4" aria-hidden="true" />
+                      ) : (
+                        <Eye className="h-4 w-4" aria-hidden="true" />
+                      )}
+                      <span className="text-sm font-semibold">{showPassword ? 'Hide' : 'Show'}</span>
+                    </button>
+                  }
+                />
+              ) : null}
+              <label className="flex items-start gap-3 rounded-2xl border border-[color:var(--color-on-surface)]/15 bg-[color:var(--color-on-surface)]/5 p-4 text-[color:var(--color-on-surface)]">
+                <input
+                  type="checkbox"
+                  className="mt-1 h-5 w-5 rounded border-[color:var(--color-on-surface)]/30 focus:ring-[color:var(--color-accent)]"
+                  checked={updatesOptIn}
+                  onChange={(event) => setUpdatesOptIn(event.target.checked)}
+                  style={{ accentColor: 'var(--color-primary)' }}
+                />
+                <span className="space-y-1">
+                  <span className="block text-base font-semibold">Send me playful Yoruba tips</span>
+                  <span className="block text-sm text-[color:var(--color-on-surface)]/70">
+                    Optional monthly email with culture bites and new lesson alerts.
+                  </span>
+                </span>
+              </label>
+              <Button type="submit" disabled={loading} className="w-full">
+                {loading ? 'Creating account…' : 'Create guardian account'}
+              </Button>
+              <p className="text-sm text-[color:var(--color-on-surface)]/70">
+                We’ll email a verification link right away. Confirm it to start adding child profiles.
+              </p>
+            </form>
+            <Divider>After sign up</Divider>
+            <div className="space-y-4 rounded-2xl border border-[color:var(--color-on-surface)]/10 bg-[color:var(--color-on-surface)]/5 p-5">
+              <p className="text-base leading-relaxed text-[color:var(--color-on-surface)]">
+                After you confirm the magic link, you can add child profiles so each kid has their own joyful space.
+              </p>
+              <Button href="/kids" variant="secondary" className="w-full sm:w-auto">
+                Add a child profile
+              </Button>
+            </div>
+            <div className="flex flex-col gap-4 pt-4 sm:flex-row sm:items-center sm:justify-between">
+              <p className="text-base text-[color:var(--color-on-surface)]">Already have an account?</p>
+              <Button href="/auth/login" variant="ghost" className="w-full sm:w-auto">
+                Log in instead
+              </Button>
+            </div>
+          </div>
+        </AuthCard>
+        <section className="space-y-6 rounded-3xl bg-[color:var(--color-surface)]/70 p-6 ring-1 ring-[color:var(--color-on-surface)]/10 backdrop-blur-sm">
+          <h2 className="text-2xl font-serif leading-tight text-[color:var(--color-on-surface)]">What you unlock</h2>
+          <p className="text-base leading-relaxed text-[color:var(--color-on-surface)]/80">
+            Your guardian account anchors every child profile, tracks their streaks, and lets you celebrate in Yoruba and English.
+          </p>
+          <ul className="space-y-4">
+            {highlightItems.map((item) => (
+              <li
+                key={item.title}
+                className="flex gap-3 rounded-2xl border border-[color:var(--color-on-surface)]/10 bg-[color:var(--color-on-surface)]/5 p-4"
+              >
+                <span className="flex h-12 w-12 items-center justify-center rounded-2xl bg-[color:var(--color-primary)]/10 text-[color:var(--color-primary)]">
+                  {item.icon}
+                </span>
+                <div className="space-y-1">
+                  <p className="text-lg font-semibold text-[color:var(--color-on-surface)]">{item.title}</p>
+                  <p className="text-base leading-relaxed text-[color:var(--color-on-surface)]/80">{item.description}</p>
+                </div>
+              </li>
+            ))}
+          </ul>
+          <div className="space-y-3 rounded-2xl bg-[color:var(--color-primary)]/10 p-5 text-[color:var(--color-on-surface)]">
+            <p className="text-base leading-relaxed">
+              Prefer to talk to a person first? We’re ready to help at{' '}
+              <a
+                href="mailto:hello@ilo.school"
+                className="font-semibold text-primary underline-offset-4 hover:underline"
+              >
+                hello@ilo.school
+              </a>{' '}
+              or visit our{' '}
+              <Link href="/help" className="font-semibold text-primary underline-offset-4 hover:underline">
+                help center
+              </Link>
+              .
+            </p>
+            <p className="text-sm text-[color:var(--color-on-surface)]/70">
+              We share monthly recaps and Yoruba celebration ideas with guardians who opt in.
+            </p>
+          </div>
+        </section>
+      </div>
     </motion.div>
   );
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -26,7 +26,7 @@
   }
 
   :focus-visible {
-    outline: 4px solid rgba(211, 126, 44, 0.6);
+    outline: 4px solid rgba(240, 93, 35, 0.55);
     outline-offset: 2px;
   }
 

--- a/components/AvatarPicker.tsx
+++ b/components/AvatarPicker.tsx
@@ -17,11 +17,11 @@ const AVATAR_OPTIONS: AvatarOption[] = [
     label: 'Sunny tortoise',
     render: (
       <svg viewBox="0 0 120 120" className="h-20 w-20" role="img" aria-label="Sunny tortoise avatar">
-        <circle cx="60" cy="60" r="56" fill="#F4E7CD" />
-        <circle cx="60" cy="54" r="32" fill="#9C5C2E" />
-        <circle cx="46" cy="48" r="6" fill="#F4E7CD" />
-        <circle cx="74" cy="48" r="6" fill="#F4E7CD" />
-        <path d="M44 70 Q60 82 76 70" stroke="#F4E7CD" strokeWidth="6" strokeLinecap="round" fill="none" />
+        <circle cx="60" cy="60" r="56" fill="#FDF6EB" />
+        <circle cx="60" cy="54" r="32" fill="#0B6E4F" />
+        <circle cx="46" cy="48" r="6" fill="#FDF6EB" />
+        <circle cx="74" cy="48" r="6" fill="#FDF6EB" />
+        <path d="M44 70 Q60 82 76 70" stroke="#FDF6EB" strokeWidth="6" strokeLinecap="round" fill="none" />
       </svg>
     ),
   },
@@ -30,10 +30,10 @@ const AVATAR_OPTIONS: AvatarOption[] = [
     label: 'Forest friend',
     render: (
       <svg viewBox="0 0 120 120" className="h-20 w-20" role="img" aria-label="Forest friend avatar">
-        <rect width="120" height="120" rx="48" fill="#4A5B3F" />
-        <circle cx="45" cy="50" r="10" fill="#F3EBDD" />
-        <circle cx="75" cy="50" r="10" fill="#F3EBDD" />
-        <path d="M40 78 Q60 94 80 78" stroke="#F3EBDD" strokeWidth="8" strokeLinecap="round" fill="none" />
+        <rect width="120" height="120" rx="48" fill="#1FC596" />
+        <circle cx="45" cy="50" r="10" fill="#FFF7F2" />
+        <circle cx="75" cy="50" r="10" fill="#FFF7F2" />
+        <path d="M40 78 Q60 94 80 78" stroke="#FFF7F2" strokeWidth="8" strokeLinecap="round" fill="none" />
       </svg>
     ),
   },
@@ -42,8 +42,8 @@ const AVATAR_OPTIONS: AvatarOption[] = [
     label: 'Laughing star',
     render: (
       <svg viewBox="0 0 120 120" className="h-20 w-20" role="img" aria-label="Laughing star avatar">
-        <rect width="120" height="120" rx="32" fill="#D37E2C" />
-        <polygon points="60,12 74,48 112,48 80,72 92,108 60,86 28,108 40,72 8,48 46,48" fill="#FCEFD6" />
+        <rect width="120" height="120" rx="32" fill="#F05D23" />
+        <polygon points="60,12 74,48 112,48 80,72 92,108 60,86 28,108 40,72 8,48 46,48" fill="#FFE9C7" />
       </svg>
     ),
   },
@@ -52,10 +52,10 @@ const AVATAR_OPTIONS: AvatarOption[] = [
     label: 'Gentle moon',
     render: (
       <svg viewBox="0 0 120 120" className="h-20 w-20" role="img" aria-label="Gentle moon avatar">
-        <circle cx="60" cy="60" r="58" fill="#2C221B" />
-        <path d="M70 20a38 38 0 1 0 0 80 38 38 0 0 1 0-80z" fill="#F4E7CD" />
-        <circle cx="48" cy="54" r="6" fill="#2C221B" />
-        <circle cx="62" cy="64" r="4" fill="#2C221B" />
+        <circle cx="60" cy="60" r="58" fill="#1E1208" />
+        <path d="M70 20a38 38 0 1 0 0 80 38 38 0 0 1 0-80z" fill="#FDF6EB" />
+        <circle cx="48" cy="54" r="6" fill="#1E1208" />
+        <circle cx="62" cy="64" r="4" fill="#1E1208" />
       </svg>
     ),
   },
@@ -64,10 +64,10 @@ const AVATAR_OPTIONS: AvatarOption[] = [
     label: 'Joyful drum',
     render: (
       <svg viewBox="0 0 120 120" className="h-20 w-20" role="img" aria-label="Joyful drum avatar">
-        <rect width="120" height="120" rx="40" fill="#F4E7CD" />
-        <ellipse cx="60" cy="36" rx="36" ry="24" fill="#9C5C2E" />
-        <rect x="30" y="36" width="60" height="54" rx="12" fill="#D37E2C" />
-        <path d="M30 60 L90 60" stroke="#9C5C2E" strokeWidth="6" />
+        <rect width="120" height="120" rx="40" fill="#FDF6EB" />
+        <ellipse cx="60" cy="36" rx="36" ry="24" fill="#0B6E4F" />
+        <rect x="30" y="36" width="60" height="54" rx="12" fill="#F05D23" />
+        <path d="M30 60 L90 60" stroke="#0B6E4F" strokeWidth="6" />
       </svg>
     ),
   },
@@ -76,11 +76,11 @@ const AVATAR_OPTIONS: AvatarOption[] = [
     label: 'Dancing mask',
     render: (
       <svg viewBox="0 0 120 120" className="h-20 w-20" role="img" aria-label="Dancing mask avatar">
-        <rect width="120" height="120" rx="44" fill="#4A5B3F" />
-        <path d="M60 20 C30 20 24 48 28 72 C32 98 48 108 60 108 C72 108 88 98 92 72 C96 48 90 20 60 20Z" fill="#F3EBDD" />
-        <circle cx="48" cy="60" r="8" fill="#4A5B3F" />
-        <circle cx="72" cy="60" r="8" fill="#4A5B3F" />
-        <path d="M44 78 Q60 88 76 78" stroke="#4A5B3F" strokeWidth="6" strokeLinecap="round" />
+        <rect width="120" height="120" rx="44" fill="#0B6E4F" />
+        <path d="M60 20 C30 20 24 48 28 72 C32 98 48 108 60 108 C72 108 88 98 92 72 C96 48 90 20 60 20Z" fill="#FDF6EB" />
+        <circle cx="48" cy="60" r="8" fill="#0B6E4F" />
+        <circle cx="72" cy="60" r="8" fill="#0B6E4F" />
+        <path d="M44 78 Q60 88 76 78" stroke="#F05D23" strokeWidth="6" strokeLinecap="round" />
       </svg>
     ),
   },
@@ -89,9 +89,9 @@ const AVATAR_OPTIONS: AvatarOption[] = [
     label: 'Spark kite',
     render: (
       <svg viewBox="0 0 120 120" className="h-20 w-20" role="img" aria-label="Spark kite avatar">
-        <rect width="120" height="120" rx="32" fill="#D37E2C" />
-        <polygon points="60,16 100,60 60,104 20,60" fill="#F4E7CD" />
-        <path d="M60 104 L60 120" stroke="#F4E7CD" strokeWidth="6" strokeLinecap="round" />
+        <rect width="120" height="120" rx="32" fill="#F05D23" />
+        <polygon points="60,16 100,60 60,104 20,60" fill="#FDF6EB" />
+        <path d="M60 104 L60 120" stroke="#FDF6EB" strokeWidth="6" strokeLinecap="round" />
       </svg>
     ),
   },
@@ -100,9 +100,9 @@ const AVATAR_OPTIONS: AvatarOption[] = [
     label: 'River wave',
     render: (
       <svg viewBox="0 0 120 120" className="h-20 w-20" role="img" aria-label="River wave avatar">
-        <rect width="120" height="120" rx="50" fill="#2C221B" />
-        <path d="M10 80 Q30 60 50 80 T90 80 T130 80" stroke="#F3EBDD" strokeWidth="10" fill="none" />
-        <path d="M10 96 Q30 76 50 96 T90 96 T130 96" stroke="#F3EBDD" strokeWidth="8" fill="none" opacity="0.6" />
+        <rect width="120" height="120" rx="50" fill="#1E1208" />
+        <path d="M10 80 Q30 60 50 80 T90 80 T130 80" stroke="#1FC596" strokeWidth="10" fill="none" />
+        <path d="M10 96 Q30 76 50 96 T90 96 T130 96" stroke="#1FC596" strokeWidth="8" fill="none" opacity="0.6" />
       </svg>
     ),
   },

--- a/components/ConfettiOnce.tsx
+++ b/components/ConfettiOnce.tsx
@@ -13,7 +13,7 @@ interface ConfettiPiece {
   color: string;
 }
 
-const COLORS = ['#D37E2C', '#9C5C2E', '#4A5B3F', '#F4E7CD', '#F9B256'];
+const COLORS = ['#F05D23', '#0B6E4F', '#F3A712', '#FDF6EB', '#1FC596'];
 
 export interface ConfettiOnceProps {
   trigger: boolean;

--- a/components/ui/Select.tsx
+++ b/components/ui/Select.tsx
@@ -1,17 +1,18 @@
 'use client';
 
 import { cn } from '@/lib/utils';
-import type { SelectHTMLAttributes } from 'react';
+import type { ReactNode, SelectHTMLAttributes } from 'react';
 import { forwardRef, useId } from 'react';
 
 export interface SelectProps extends SelectHTMLAttributes<HTMLSelectElement> {
   label?: string;
   helperText?: string;
   errorText?: string;
+  leadingIcon?: ReactNode;
 }
 
 export const Select = forwardRef<HTMLSelectElement, SelectProps>(function Select(
-  { label, helperText, errorText, className, id, children, ...props },
+  { label, helperText, errorText, className, id, children, leadingIcon, ...props },
   ref,
 ) {
   const generatedId = useId();
@@ -27,15 +28,20 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(function Select
       ) : null}
       <div
         className={cn(
-          'relative flex min-h-[56px] items-center rounded-2xl border border-[color:var(--color-on-surface)]/10 bg-surface px-4 text-lg shadow-sm transition focus-within:border-primary focus-within:ring-2 focus-within:ring-[var(--color-accent)] focus-within:ring-offset-2 focus-within:ring-offset-[var(--color-surface)]',
+          'relative flex min-h-[56px] items-center gap-3 rounded-2xl border border-[color:var(--color-on-surface)]/10 bg-surface px-4 text-lg shadow-sm transition focus-within:border-primary focus-within:ring-2 focus-within:ring-[var(--color-accent)] focus-within:ring-offset-2 focus-within:ring-offset-[var(--color-surface)]',
           errorText ? 'border-red-600 focus-within:border-red-600 focus-within:ring-red-500/40' : null,
         )}
       >
+        {leadingIcon ? (
+          <span aria-hidden="true" className="text-[color:var(--color-on-surface)]/70">
+            {leadingIcon}
+          </span>
+        ) : null}
         <select
           ref={ref}
           id={selectId}
           className={cn(
-            'w-full appearance-none bg-transparent pr-8 text-lg c-on-surface focus:outline-none',
+            'w-full flex-1 appearance-none bg-transparent pr-8 text-lg c-on-surface focus:outline-none',
             className,
           )}
           aria-describedby={descriptionId}

--- a/lib/zodSchemas.ts
+++ b/lib/zodSchemas.ts
@@ -31,6 +31,7 @@ export const guardianSignupSchema = z.object({
     .union([passwordSchema, z.literal('')])
     .optional()
     .transform((value) => (value ? value : undefined)),
+  updatesOptIn: z.boolean().optional().default(false),
 });
 
 export type GuardianSignupInput = z.infer<typeof guardianSignupSchema>;

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,13 +1,13 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 512 512">
-  <path d="M96 144L256 48l160 96v96H96z" fill="#9C5C2E"/>
-  <path d="M96 144L256 48l160 96" stroke="#D37E2C" stroke-width="16"/>
-  <path d="M96 240h320" stroke="#D37E2C" stroke-width="16"/>
-  <circle cx="256" cy="312" r="176" fill="#C4A574"/>
-  <ellipse cx="186" cy="276" rx="36" ry="44" fill="#fff"/>
-  <ellipse cx="326" cy="276" rx="36" ry="44" fill="#fff"/>
-  <circle cx="186" cy="276" r="18" fill="#2C221B"/>
-  <circle cx="326" cy="276" r="18" fill="#2C221B"/>
-  <path d="M176 360c40 40 120 40 160 0" stroke="#2C221B" stroke-width="12" stroke-linecap="round" fill="none"/>
-  <circle cx="136" cy="306" r="20" fill="#F4A7A3"/>
-  <circle cx="376" cy="306" r="20" fill="#F4A7A3"/>
+  <path d="M96 144L256 48l160 96v96H96z" fill="#0B6E4F"/>
+  <path d="M96 144L256 48l160 96" stroke="#F05D23" stroke-width="16"/>
+  <path d="M96 240h320" stroke="#F05D23" stroke-width="16"/>
+  <circle cx="256" cy="312" r="176" fill="#F3A712"/>
+  <ellipse cx="186" cy="276" rx="36" ry="44" fill="#FFF7F2"/>
+  <ellipse cx="326" cy="276" rx="36" ry="44" fill="#FFF7F2"/>
+  <circle cx="186" cy="276" r="18" fill="#1E1208"/>
+  <circle cx="326" cy="276" r="18" fill="#1E1208"/>
+  <path d="M176 360c40 40 120 40 160 0" stroke="#1E1208" stroke-width="12" stroke-linecap="round" fill="none"/>
+  <circle cx="136" cy="306" r="20" fill="#FFB8A6"/>
+  <circle cx="376" cy="306" r="20" fill="#FFB8A6"/>
 </svg>

--- a/public/icons/icon-192x192.svg
+++ b/public/icons/icon-192x192.svg
@@ -1,13 +1,13 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="192" height="192" viewBox="0 0 512 512">
-  <path d="M96 144L256 48l160 96v96H96z" fill="#9C5C2E"/>
-  <path d="M96 144L256 48l160 96" stroke="#D37E2C" stroke-width="16"/>
-  <path d="M96 240h320" stroke="#D37E2C" stroke-width="16"/>
-  <circle cx="256" cy="312" r="176" fill="#C4A574"/>
-  <ellipse cx="186" cy="276" rx="36" ry="44" fill="#fff"/>
-  <ellipse cx="326" cy="276" rx="36" ry="44" fill="#fff"/>
-  <circle cx="186" cy="276" r="18" fill="#2C221B"/>
-  <circle cx="326" cy="276" r="18" fill="#2C221B"/>
-  <path d="M176 360c40 40 120 40 160 0" stroke="#2C221B" stroke-width="12" stroke-linecap="round" fill="none"/>
-  <circle cx="136" cy="306" r="20" fill="#F4A7A3"/>
-  <circle cx="376" cy="306" r="20" fill="#F4A7A3"/>
+  <path d="M96 144L256 48l160 96v96H96z" fill="#0B6E4F"/>
+  <path d="M96 144L256 48l160 96" stroke="#F05D23" stroke-width="16"/>
+  <path d="M96 240h320" stroke="#F05D23" stroke-width="16"/>
+  <circle cx="256" cy="312" r="176" fill="#F3A712"/>
+  <ellipse cx="186" cy="276" rx="36" ry="44" fill="#FFF7F2"/>
+  <ellipse cx="326" cy="276" rx="36" ry="44" fill="#FFF7F2"/>
+  <circle cx="186" cy="276" r="18" fill="#1E1208"/>
+  <circle cx="326" cy="276" r="18" fill="#1E1208"/>
+  <path d="M176 360c40 40 120 40 160 0" stroke="#1E1208" stroke-width="12" stroke-linecap="round" fill="none"/>
+  <circle cx="136" cy="306" r="20" fill="#FFB8A6"/>
+  <circle cx="376" cy="306" r="20" fill="#FFB8A6"/>
 </svg>

--- a/public/icons/icon-256x256.svg
+++ b/public/icons/icon-256x256.svg
@@ -1,13 +1,13 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewBox="0 0 512 512">
-  <path d="M96 144L256 48l160 96v96H96z" fill="#9C5C2E"/>
-  <path d="M96 144L256 48l160 96" stroke="#D37E2C" stroke-width="16"/>
-  <path d="M96 240h320" stroke="#D37E2C" stroke-width="16"/>
-  <circle cx="256" cy="312" r="176" fill="#C4A574"/>
-  <ellipse cx="186" cy="276" rx="36" ry="44" fill="#fff"/>
-  <ellipse cx="326" cy="276" rx="36" ry="44" fill="#fff"/>
-  <circle cx="186" cy="276" r="18" fill="#2C221B"/>
-  <circle cx="326" cy="276" r="18" fill="#2C221B"/>
-  <path d="M176 360c40 40 120 40 160 0" stroke="#2C221B" stroke-width="12" stroke-linecap="round" fill="none"/>
-  <circle cx="136" cy="306" r="20" fill="#F4A7A3"/>
-  <circle cx="376" cy="306" r="20" fill="#F4A7A3"/>
+  <path d="M96 144L256 48l160 96v96H96z" fill="#0B6E4F"/>
+  <path d="M96 144L256 48l160 96" stroke="#F05D23" stroke-width="16"/>
+  <path d="M96 240h320" stroke="#F05D23" stroke-width="16"/>
+  <circle cx="256" cy="312" r="176" fill="#F3A712"/>
+  <ellipse cx="186" cy="276" rx="36" ry="44" fill="#FFF7F2"/>
+  <ellipse cx="326" cy="276" rx="36" ry="44" fill="#FFF7F2"/>
+  <circle cx="186" cy="276" r="18" fill="#1E1208"/>
+  <circle cx="326" cy="276" r="18" fill="#1E1208"/>
+  <path d="M176 360c40 40 120 40 160 0" stroke="#1E1208" stroke-width="12" stroke-linecap="round" fill="none"/>
+  <circle cx="136" cy="306" r="20" fill="#FFB8A6"/>
+  <circle cx="376" cy="306" r="20" fill="#FFB8A6"/>
 </svg>

--- a/public/icons/icon-512x512.svg
+++ b/public/icons/icon-512x512.svg
@@ -1,13 +1,13 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512">
-  <path d="M96 144L256 48l160 96v96H96z" fill="#9C5C2E"/>
-  <path d="M96 144L256 48l160 96" stroke="#D37E2C" stroke-width="16"/>
-  <path d="M96 240h320" stroke="#D37E2C" stroke-width="16"/>
-  <circle cx="256" cy="312" r="176" fill="#C4A574"/>
-  <ellipse cx="186" cy="276" rx="36" ry="44" fill="#fff"/>
-  <ellipse cx="326" cy="276" rx="36" ry="44" fill="#fff"/>
-  <circle cx="186" cy="276" r="18" fill="#2C221B"/>
-  <circle cx="326" cy="276" r="18" fill="#2C221B"/>
-  <path d="M176 360c40 40 120 40 160 0" stroke="#2C221B" stroke-width="12" stroke-linecap="round" fill="none"/>
-  <circle cx="136" cy="306" r="20" fill="#F4A7A3"/>
-  <circle cx="376" cy="306" r="20" fill="#F4A7A3"/>
+  <path d="M96 144L256 48l160 96v96H96z" fill="#0B6E4F"/>
+  <path d="M96 144L256 48l160 96" stroke="#F05D23" stroke-width="16"/>
+  <path d="M96 240h320" stroke="#F05D23" stroke-width="16"/>
+  <circle cx="256" cy="312" r="176" fill="#F3A712"/>
+  <ellipse cx="186" cy="276" rx="36" ry="44" fill="#FFF7F2"/>
+  <ellipse cx="326" cy="276" rx="36" ry="44" fill="#FFF7F2"/>
+  <circle cx="186" cy="276" r="18" fill="#1E1208"/>
+  <circle cx="326" cy="276" r="18" fill="#1E1208"/>
+  <path d="M176 360c40 40 120 40 160 0" stroke="#1E1208" stroke-width="12" stroke-linecap="round" fill="none"/>
+  <circle cx="136" cy="306" r="20" fill="#FFB8A6"/>
+  <circle cx="376" cy="306" r="20" fill="#FFB8A6"/>
 </svg>

--- a/public/icons/maskable-icon-512x512.svg
+++ b/public/icons/maskable-icon-512x512.svg
@@ -1,13 +1,13 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512">
-  <path d="M96 144L256 48l160 96v96H96z" fill="#9C5C2E"/>
-  <path d="M96 144L256 48l160 96" stroke="#D37E2C" stroke-width="16"/>
-  <path d="M96 240h320" stroke="#D37E2C" stroke-width="16"/>
-  <circle cx="256" cy="312" r="176" fill="#C4A574"/>
-  <ellipse cx="186" cy="276" rx="36" ry="44" fill="#fff"/>
-  <ellipse cx="326" cy="276" rx="36" ry="44" fill="#fff"/>
-  <circle cx="186" cy="276" r="18" fill="#2C221B"/>
-  <circle cx="326" cy="276" r="18" fill="#2C221B"/>
-  <path d="M176 360c40 40 120 40 160 0" stroke="#2C221B" stroke-width="12" stroke-linecap="round" fill="none"/>
-  <circle cx="136" cy="306" r="20" fill="#F4A7A3"/>
-  <circle cx="376" cy="306" r="20" fill="#F4A7A3"/>
+  <path d="M96 144L256 48l160 96v96H96z" fill="#0B6E4F"/>
+  <path d="M96 144L256 48l160 96" stroke="#F05D23" stroke-width="16"/>
+  <path d="M96 240h320" stroke="#F05D23" stroke-width="16"/>
+  <circle cx="256" cy="312" r="176" fill="#F3A712"/>
+  <ellipse cx="186" cy="276" rx="36" ry="44" fill="#FFF7F2"/>
+  <ellipse cx="326" cy="276" rx="36" ry="44" fill="#FFF7F2"/>
+  <circle cx="186" cy="276" r="18" fill="#1E1208"/>
+  <circle cx="326" cy="276" r="18" fill="#1E1208"/>
+  <path d="M176 360c40 40 120 40 160 0" stroke="#1E1208" stroke-width="12" stroke-linecap="round" fill="none"/>
+  <circle cx="136" cy="306" r="20" fill="#FFB8A6"/>
+  <circle cx="376" cy="306" r="20" fill="#FFB8A6"/>
 </svg>

--- a/public/logo/tortoise.svg
+++ b/public/logo/tortoise.svg
@@ -1,13 +1,13 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
-  <path d="M96 144L256 48l160 96v96H96z" fill="#9C5C2E"/>
-  <path d="M96 144L256 48l160 96" stroke="#D37E2C" stroke-width="16"/>
-  <path d="M96 240h320" stroke="#D37E2C" stroke-width="16"/>
-  <circle cx="256" cy="312" r="176" fill="#C4A574"/>
-  <ellipse cx="186" cy="276" rx="36" ry="44" fill="#fff"/>
-  <ellipse cx="326" cy="276" rx="36" ry="44" fill="#fff"/>
-  <circle cx="186" cy="276" r="18" fill="#2C221B"/>
-  <circle cx="326" cy="276" r="18" fill="#2C221B"/>
-  <path d="M176 360c40 40 120 40 160 0" stroke="#2C221B" stroke-width="12" stroke-linecap="round" fill="none"/>
-  <circle cx="136" cy="306" r="20" fill="#F4A7A3"/>
-  <circle cx="376" cy="306" r="20" fill="#F4A7A3"/>
+  <path d="M96 144L256 48l160 96v96H96z" fill="#0B6E4F"/>
+  <path d="M96 144L256 48l160 96" stroke="#F05D23" stroke-width="16"/>
+  <path d="M96 240h320" stroke="#F05D23" stroke-width="16"/>
+  <circle cx="256" cy="312" r="176" fill="#F3A712"/>
+  <ellipse cx="186" cy="276" rx="36" ry="44" fill="#FFF7F2"/>
+  <ellipse cx="326" cy="276" rx="36" ry="44" fill="#FFF7F2"/>
+  <circle cx="186" cy="276" r="18" fill="#1E1208"/>
+  <circle cx="326" cy="276" r="18" fill="#1E1208"/>
+  <path d="M176 360c40 40 120 40 160 0" stroke="#1E1208" stroke-width="12" stroke-linecap="round" fill="none"/>
+  <circle cx="136" cy="306" r="20" fill="#FFB8A6"/>
+  <circle cx="376" cy="306" r="20" fill="#FFB8A6"/>
 </svg>

--- a/styles/theme.css
+++ b/styles/theme.css
@@ -1,19 +1,19 @@
 :root {
-  --color-primary: #9C5C2E;
-  --color-on-primary: #FFFFFF;
-  --color-secondary: #4A5B3F;
-  --color-on-secondary: #FFFFFF;
-  --color-accent: #D37E2C;
-  --color-on-accent: #1F140D;
-  --color-paper: #F4E7CD;
-  --color-on-paper: #2C221B;
+  --color-primary: #0B6E4F;
+  --color-on-primary: #F1FFF7;
+  --color-secondary: #F3A712;
+  --color-on-secondary: #2F1D04;
+  --color-accent: #F05D23;
+  --color-on-accent: #FFF7F2;
+  --color-paper: #FDF6EB;
+  --color-on-paper: #1E1208;
   --color-surface: #FFFFFF;
-  --color-on-surface: #2C221B;
+  --color-on-surface: #1E1208;
   --color-ink: var(--color-on-paper);
 
   --radius-xl: 1.25rem;
-  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.06);
-  --shadow-md: 0 6px 16px rgba(0, 0, 0, 0.1);
+  --shadow-sm: 0 1px 2px rgba(15, 23, 18, 0.08);
+  --shadow-md: 0 10px 30px rgba(13, 33, 26, 0.12);
 
   --font-ui: 'Noto Sans', system-ui, -apple-system, 'Segoe UI', Roboto, 'Helvetica Neue', Arial,
     'Apple Color Emoji', 'Segoe UI Emoji';
@@ -22,11 +22,17 @@
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --color-paper: #2A241E;
-    --color-on-paper: #F3EBDD;
-    --color-surface: #2F281F;
-    --color-on-surface: #F3EBDD;
-    --color-on-accent: #F3EBDD;
+    --color-primary: #1FC596;
+    --color-on-primary: #06271F;
+    --color-secondary: #F6C64F;
+    --color-on-secondary: #2C1E05;
+    --color-accent: #FF7A45;
+    --color-on-accent: #2B1409;
+    --color-paper: #18120C;
+    --color-on-paper: #F8EFE3;
+    --color-surface: #221910;
+    --color-on-surface: #F8EFE3;
+    --color-ink: var(--color-on-paper);
   }
 }
 


### PR DESCRIPTION
## Summary
- Refresh the Ìlọ̀ colour palette and update shared assets, avatars, and confetti effects to match the new brand direction.
- Rework the sign-in experience with guided copy, validation icons, and a support sidebar for guardians.
- Expand the sign-up flow with a step tracker, optional update opt-in stored in Supabase metadata, and richer helper content.

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68cf302b36c083339a56ffeddd5f99b4