### PR TITLE
Fix lucide icon import to unblock Next.js build

### DIFF
--- a/app/(public)/auth/login/page.tsx
+++ b/app/(public)/auth/login/page.tsx
@@ -9,7 +9,7 @@ import { usePageEnter } from '@/lib/anim';
 import { supabaseBrowser } from '@/lib/supabaseBrowser';
 import { emailSchema, passwordSchema } from '@/lib/zodSchemas';
 import { motion } from 'framer-motion';
-import { CheckCircle2, Clock3, Eye, EyeOff, Lock, LogIn, Mail, ShieldCheck, UsersRound } from 'lucide-react';
+import { CheckCircle2, Clock3, Eye, EyeOff, Lock, LogIn, Mail, ShieldCheck, Users } from 'lucide-react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { type FormEvent, useMemo, useState } from 'react';
@@ -87,7 +87,7 @@ export default function LoginPage() {
       {
         title: 'Guardian controls',
         description: 'Manage passwords and child profiles from your family dashboard.',
-        icon: <UsersRound className="h-6 w-6" aria-hidden="true" />,
+        icon: <Users className="h-6 w-6" aria-hidden="true" />,
       },
     ],
     [],


### PR DESCRIPTION
## Summary
- replace the nonexistent `UsersRound` lucide-react icon with the supported `Users` icon on the auth login page to fix the production build

## Testing
- NEXT_PUBLIC_SUPABASE_URL=foo NEXT_PUBLIC_SUPABASE_ANON_KEY=bar pnpm run build

------
https://chatgpt.com/codex/tasks/task_e_68cf366a4db483339dc12f1b5faf3ba0