### PR TITLE
Make navigation fixed and refresh footer art

### DIFF
--- a/app/(marketing)/layout.tsx
+++ b/app/(marketing)/layout.tsx
@@ -10,7 +10,7 @@ export default function MarketingLayout({ children }: { children: React.ReactNod
   return (
     <>
       <NavBar />
-      {children}
+      <main className="pt-24">{children}</main>
       <Footer />
       <CookieBanner />
       <FloatingWhatsApp />

--- a/app/(public)/layout.tsx
+++ b/app/(public)/layout.tsx
@@ -6,7 +6,10 @@ import { InstallPrompt } from '@/components/InstallPrompt';
 export default function PublicLayout({ children }: { children: ReactNode }) {
   return (
     <div className="flex min-h-screen flex-col bg-paper text-ink">
-      <header className="border-b border-ink/10 bg-paper/90" role="banner">
+      <header
+        className="fixed inset-x-0 top-0 z-40 border-b border-ink/10 bg-paper/95 backdrop-blur supports-[backdrop-filter]:bg-paper/80"
+        role="banner"
+      >
         <div className="mx-auto flex w-full max-w-screen-lg items-center justify-between gap-6 px-4 py-4">
           <Link href="/" className="flex items-center gap-3 text-2xl font-serif">
             <span className="flex h-12 w-12 items-center justify-center rounded-full bg-primary/10 text-3xl" aria-hidden="true">
@@ -38,7 +41,7 @@ export default function PublicLayout({ children }: { children: ReactNode }) {
           </div>
         </div>
       </header>
-      <main id="main-content" className="mx-auto w-full max-w-screen-lg flex-1 px-4 py-10" role="main">
+      <main id="main-content" className="mx-auto w-full max-w-screen-lg flex-1 px-4 pb-10 pt-28 md:pt-32" role="main">
         {children}
       </main>
       <aside className="border-t border-ink/10 bg-paper/95 px-4 py-8">

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -1,22 +1,206 @@
-import Link from 'next/link';
 import Image from 'next/image';
+import Link from 'next/link';
+
+type FooterLink = {
+  label: string;
+  href: string;
+  external?: boolean;
+};
+
+type FooterSection = {
+  heading: string;
+  links: FooterLink[];
+};
+
+const SECTIONS: FooterSection[] = [
+  {
+    heading: 'Product',
+    links: [
+      { label: 'Features', href: '/features' },
+      { label: 'Pricing', href: '/pricing' },
+      { label: 'Status', href: '/status' },
+    ],
+  },
+  {
+    heading: 'Company',
+    links: [
+      { label: 'About', href: '/about' },
+      { label: 'Blog', href: '/blog' },
+      { label: 'FAQ', href: '/faq' },
+    ],
+  },
+  {
+    heading: 'Connect',
+    links: [
+      { label: 'WhatsApp', href: 'https://wa.me/2348104024943', external: true },
+      { label: 'Instagram', href: 'https://instagram.com', external: true },
+      { label: 'Twitter', href: 'https://twitter.com', external: true },
+    ],
+  },
+];
+
+function MeadowScene({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 1200 220"
+      className={className ? `w-full ${className}` : 'w-full'}
+      preserveAspectRatio="none"
+      aria-hidden="true"
+      focusable="false"
+    >
+      <rect width="1200" height="220" fill="#FFF8F1" />
+      <path
+        d="M0 150 C120 120 240 180 360 150 C520 120 680 190 840 150 C960 130 1080 170 1200 150 L1200 220 L0 220 Z"
+        fill="#FBE4CC"
+      />
+      <path
+        d="M0 182 C140 158 280 210 420 182 C600 150 780 215 960 195 C1080 185 1140 204 1200 198 L1200 220 L0 220 Z"
+        fill="#F6D5B3"
+      />
+      <circle cx="1050" cy="70" r="34" fill="#FFD77E" opacity="0.6" />
+      <g transform="translate(130 118)">
+        <rect x="-7" y="40" width="14" height="62" rx="5" fill="#AA7658" />
+        <circle cx="0" cy="26" r="26" fill="#4CA676" />
+        <circle cx="-18" cy="44" r="18" fill="#5BBB86" />
+        <circle cx="18" cy="44" r="18" fill="#5BBB86" />
+      </g>
+      <g transform="translate(350 128)">
+        <rect x="-6" y="44" width="12" height="62" rx="5" fill="#8F6044" />
+        <path d="M0 0 L-34 48 L34 48 Z" fill="#4CA676" />
+        <path d="M0 16 L-28 60 L28 60 Z" fill="#5DBB86" opacity="0.85" />
+      </g>
+      <g transform="translate(610 116)">
+        <rect x="-8" y="46" width="16" height="66" rx="6" fill="#99664A" />
+        <ellipse cx="0" cy="20" rx="34" ry="44" fill="#4C9C6F" />
+        <ellipse cx="-24" cy="48" rx="18" ry="24" fill="#5FB381" />
+        <ellipse cx="24" cy="48" rx="18" ry="24" fill="#5FB381" />
+      </g>
+      <g transform="translate(890 130)">
+        <rect x="-5" y="36" width="10" height="58" rx="5" fill="#8F6044" />
+        <path d="M0 0 L-26 42 L0 74 L26 42 Z" fill="#54B082" />
+      </g>
+      <g transform="translate(250 182)">
+        <rect x="-2" y="0" width="4" height="36" rx="2" fill="#6DBE84" />
+        <g transform="translate(0,-8)">
+          <circle cx="0" cy="0" r="9" fill="#FF8BB6" />
+          <circle cx="0" cy="-10" r="4" fill="#FFD8E8" />
+          <circle cx="8" cy="-2" r="4" fill="#FFD8E8" />
+          <circle cx="-8" cy="-2" r="4" fill="#FFD8E8" />
+          <circle cx="0" cy="0" r="3" fill="#FFF6FA" />
+        </g>
+      </g>
+      <g transform="translate(520 188)">
+        <rect x="-1.5" y="0" width="3" height="30" rx="1.5" fill="#63B778" />
+        <g transform="translate(0,-8)">
+          <path d="M0 -6 C6 -4 8 4 4 8 C0 12 -6 12 -10 6 C-14 0 -10 -8 0 -6 Z" fill="#FFCE76" />
+          <circle cx="0" cy="2" r="3" fill="#F7B84B" />
+        </g>
+      </g>
+      <g transform="translate(760 180)">
+        <rect x="-2" y="0" width="4" height="34" rx="2" fill="#63B778" />
+        <g transform="translate(0,-7)">
+          <circle cx="0" cy="0" r="8" fill="#8AC6FF" />
+          <circle cx="0" cy="-8" r="4" fill="#C6E7FF" />
+          <circle cx="7" cy="-3" r="4" fill="#C6E7FF" />
+          <circle cx="-7" cy="-3" r="4" fill="#C6E7FF" />
+          <circle cx="0" cy="0" r="3" fill="#EAF6FF" />
+        </g>
+      </g>
+      <g transform="translate(1030 186)">
+        <rect x="-1.5" y="0" width="3" height="32" rx="1.5" fill="#63B778" />
+        <g transform="translate(0,-6)">
+          <circle cx="0" cy="0" r="7" fill="#FF9F80" />
+          <circle cx="0" cy="-7" r="3.5" fill="#FFC9B0" />
+          <circle cx="6" cy="-2" r="3.5" fill="#FFC9B0" />
+          <circle cx="-6" cy="-2" r="3.5" fill="#FFC9B0" />
+          <circle cx="0" cy="0" r="2.5" fill="#FFE6DC" />
+        </g>
+      </g>
+      <g fill="#F2CBB0" opacity="0.5">
+        <circle cx="140" cy="70" r="6" />
+        <circle cx="280" cy="40" r="4" />
+        <circle cx="460" cy="62" r="5" />
+        <circle cx="720" cy="48" r="4" />
+        <circle cx="840" cy="64" r="6" />
+      </g>
+    </svg>
+  );
+}
+
+function SproutAccent({ className = 'h-10 w-full max-w-xs text-primary/70' }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 160 40"
+      className={className}
+      aria-hidden="true"
+      focusable="false"
+    >
+      <path d="M20 32 C22 20 36 10 52 12 C42 18 30 26 20 32 Z" fill="currentColor" opacity="0.35" />
+      <path d="M68 32 C70 18 90 6 112 10 C98 18 84 24 68 32 Z" fill="currentColor" opacity="0.45" />
+      <path d="M118 32 C118 22 130 14 144 16 C136 22 128 26 118 32 Z" fill="currentColor" opacity="0.35" />
+      <rect x="78" y="12" width="4" height="20" rx="2" fill="currentColor" opacity="0.45" />
+    </svg>
+  );
+}
 
 export default function Footer() {
+  const year = new Date().getFullYear();
   return (
-    <footer className="bg-cream border-t mt-12">
-      <div className="container mx-auto p-6 grid gap-4 md:grid-cols-3 text-sm">
-        <div>
-          <Image src="/logo/tortoise.svg" alt="Ìlọ̀" width={40} height={40} />
-          <p className="mt-2">© {new Date().getFullYear()} Ìlọ̀.</p>
+    <footer className="relative mt-24 overflow-hidden bg-[#FFF8F1] text-ink">
+      <div className="-mb-12">
+        <MeadowScene className="h-48 md:h-56" />
+      </div>
+      <div className="mx-auto max-w-6xl px-6 pb-12 pt-6 md:pt-8">
+        <div className="grid gap-10 md:grid-cols-[1.2fr_1fr_1fr_1fr]">
+          <div className="space-y-5">
+            <Link href="/" className="inline-flex items-center gap-3 text-ink">
+              <Image src="/logo/tortoise.svg" alt="Ìlọ̀" width={48} height={48} className="h-12 w-12" />
+              <span className="font-serif text-3xl">Ìlọ̀</span>
+            </Link>
+            <p className="max-w-sm text-base text-ink/75">
+              Playful Yorùbá learning that grows with every child. Stories, songs, and laughter lead the way.
+            </p>
+            <SproutAccent />
+          </div>
+          {SECTIONS.map((section) => (
+            <div key={section.heading} className="space-y-4">
+              <p className="font-title text-lg text-ink/80">{section.heading}</p>
+              <ul className="space-y-3 text-sm text-ink/70">
+                {section.links.map((link) => (
+                  <li key={link.label}>
+                    {link.external ? (
+                      <a
+                        href={link.href}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="transition-colors hover:text-primary focus-visible:underline"
+                      >
+                        {link.label}
+                      </a>
+                    ) : (
+                      <Link href={link.href} className="transition-colors hover:text-primary focus-visible:underline">
+                        {link.label}
+                      </Link>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
         </div>
-        <div className="flex flex-col space-y-2">
-          <Link href="/privacy">Privacy</Link>
-          <Link href="/terms">Terms</Link>
-          <Link href="/status">Status</Link>
-        </div>
-        <div className="flex flex-col space-y-2">
-          <a href="https://twitter.com" target="_blank" rel="noopener noreferrer">Twitter</a>
-          <a href="https://instagram.com" target="_blank" rel="noopener noreferrer">Instagram</a>
+        <div className="mt-12 flex flex-col gap-4 border-t border-ink/10 pt-6 text-sm text-ink/60 md:flex-row md:items-center md:justify-between">
+          <p>© {year} Ìlọ̀. Sprouting smiles from Lagos to the world.</p>
+          <div className="flex flex-wrap items-center gap-4">
+            <Link href="/privacy" className="transition-colors hover:text-primary focus-visible:underline">
+              Privacy
+            </Link>
+            <Link href="/terms" className="transition-colors hover:text-primary focus-visible:underline">
+              Terms
+            </Link>
+            <Link href="/status" className="transition-colors hover:text-primary focus-visible:underline">
+              Status
+            </Link>
+          </div>
         </div>
       </div>
     </footer>

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -9,7 +9,7 @@ import { cn } from '@/lib/utils';
 export default function NavBar() {
   const [open, setOpen] = useState(false);
   return (
-    <nav className="sticky top-0 z-20 bg-cream/80 backdrop-blur">
+    <nav className="fixed inset-x-0 top-0 z-50 border-b border-ink/10 bg-cream/90 backdrop-blur supports-[backdrop-filter]:bg-cream/80">
       <div className="mx-auto flex max-w-6xl items-center justify-between p-4">
         <Link href="/" className="flex items-center space-x-2 font-bold">
           <Image

--- a/public/images/mockups/avatar1.svg
+++ b/public/images/mockups/avatar1.svg
@@ -1,5 +1,20 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40">
-  <circle cx="20" cy="20" r="20" fill="#FFB703"/>
-  <circle cx="14" cy="16" r="3" fill="#0F172A"/>
-  <circle cx="26" cy="16" r="3" fill="#0F172A"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 96">
+  <rect width="96" height="96" rx="28" fill="#FFF1D0" />
+  <path d="M22 46C20 28 34 14 48 14C62 14 76 28 74 46C72 64 62 76 48 76C34 76 24 64 22 46Z" fill="#4D2D52" />
+  <path d="M30 70C36 78 44 82 48 82C52 82 60 78 66 70C55 66 41 66 30 70Z" fill="#3C7A66" />
+  <path d="M48 24C41 24 34 32 34 40C34 50 40 62 48 62C56 62 62 50 62 40C62 32 55 24 48 24Z" fill="#F9C8AA" />
+  <circle cx="35" cy="44" r="3" fill="#2D1F3D" />
+  <circle cx="61" cy="44" r="3" fill="#2D1F3D" />
+  <path d="M40 53C43 56 53 56 56 53C54 58 50 61 48 61C46 61 42 58 40 53Z" fill="#D46F6F" />
+  <circle cx="38" cy="49" r="2" fill="#F7A199" opacity="0.6" />
+  <circle cx="58" cy="49" r="2" fill="#F7A199" opacity="0.6" />
+  <g transform="translate(66 30)">
+    <circle cx="0" cy="0" r="5" fill="#FF8BB6" />
+    <circle cx="0" cy="-6" r="3" fill="#FFD6E8" />
+    <circle cx="5" cy="0" r="3" fill="#FFD6E8" />
+    <circle cx="-5" cy="0" r="3" fill="#FFD6E8" />
+    <circle cx="0" cy="0" r="2" fill="#FFF9FC" />
+  </g>
+  <path d="M60 22C62 18 68 16 72 18C68 22 64 24 60 22Z" fill="#5EAA7A" />
+  <path d="M24 22C26 18 32 16 36 18C32 22 28 24 24 22Z" fill="#5EAA7A" />
 </svg>

--- a/public/images/mockups/avatar2.svg
+++ b/public/images/mockups/avatar2.svg
@@ -1,5 +1,14 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40">
-  <circle cx="20" cy="20" r="20" fill="#1C7C54"/>
-  <circle cx="14" cy="16" r="3" fill="#FFF8EF"/>
-  <circle cx="26" cy="16" r="3" fill="#FFF8EF"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 96">
+  <rect width="96" height="96" rx="28" fill="#E2F2F1" />
+  <path d="M24 72C32 78 40 82 48 82C56 82 64 78 72 72C60 66 36 66 24 72Z" fill="#2E6F70" />
+  <path d="M18 46C20 32 34 24 48 24C62 24 76 32 78 46C76 60 66 70 48 70C30 70 20 60 18 46Z" fill="#3B8C6A" />
+  <path d="M48 28C40 28 34 36 34 46C34 56 40 64 48 64C56 64 62 56 62 46C62 36 56 28 48 28Z" fill="#F5C7A8" />
+  <circle cx="38" cy="48" r="3" fill="#1E3A3B" />
+  <circle cx="58" cy="48" r="3" fill="#1E3A3B" />
+  <path d="M40 57C44 60 52 60 56 57C54 62 50 65 48 65C46 65 42 62 40 57Z" fill="#D77474" />
+  <circle cx="38" cy="52" r="2" fill="#F5A9A2" opacity="0.6" />
+  <circle cx="58" cy="52" r="2" fill="#F5A9A2" opacity="0.6" />
+  <path d="M24 38C26 32 32 30 38 32C34 36 30 38 24 38Z" fill="#5FBF86" />
+  <path d="M58 30C62 26 70 26 74 30C68 32 64 32 58 30Z" fill="#5FBF86" />
+  <path d="M68 40C70 34 76 32 80 34C76 38 72 40 68 40Z" fill="#5FBF86" />
 </svg>

--- a/public/images/mockups/avatar3.svg
+++ b/public/images/mockups/avatar3.svg
@@ -1,5 +1,20 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40">
-  <circle cx="20" cy="20" r="20" fill="#1C7C54"/>
-  <circle cx="14" cy="16" r="3" fill="#FFB703"/>
-  <circle cx="26" cy="16" r="3" fill="#FFB703"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 96">
+  <rect width="96" height="96" rx="28" fill="#F3E8FF" />
+  <path d="M22 44C24 28 36 20 48 20C60 20 72 28 74 44C72 60 62 74 48 74C34 74 24 60 22 44Z" fill="#3F3A83" />
+  <path d="M30 70C38 78 44 82 48 82C52 82 58 78 66 70C54 66 42 66 30 70Z" fill="#4E5DAA" />
+  <path d="M48 26C40 26 34 34 34 44C34 54 40 62 48 62C56 62 62 54 62 44C62 34 56 26 48 26Z" fill="#F6C7B4" />
+  <circle cx="38" cy="46" r="3" fill="#231B4A" />
+  <circle cx="58" cy="46" r="3" fill="#231B4A" />
+  <path d="M42 55C45 58 51 58 54 55C52 60 50 63 48 63C46 63 44 60 42 55Z" fill="#D97B85" />
+  <circle cx="38" cy="50" r="2" fill="#F5A2A6" opacity="0.6" />
+  <circle cx="58" cy="50" r="2" fill="#F5A2A6" opacity="0.6" />
+  <g transform="translate(48 28)">
+    <path d="M-18 8C-14 0 -4 -2 0 2C4 -2 14 0 18 8C12 8 6 10 0 10C-6 10 -12 8 -18 8Z" fill="#6EC1A6" />
+    <circle cx="-10" cy="4" r="3" fill="#FF9FC2" />
+    <circle cx="0" cy="2" r="4" fill="#FFD3E5" />
+    <circle cx="10" cy="4" r="3" fill="#FF9FC2" />
+  </g>
+  <path d="M22 32C24 26 32 24 38 26C34 30 28 32 22 32Z" fill="#74C7AF" />
+  <path d="M58 24C62 20 70 20 74 24C68 26 64 26 58 24Z" fill="#74C7AF" />
+  <circle cx="70" cy="60" r="6" fill="#FFD771" opacity="0.4" />
 </svg>


### PR DESCRIPTION
## Summary
- pin the marketing and public navigation bars so they stay visible while scrolling
- design a new SVG-based footer scene with tree and flower silhouettes and refreshed link layout
- replace testimonial avatar placeholders with richer SVG character badges

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68cfdd7c89408333aa4732fe0f1bd736