### PR TITLE
Fix Vercel build failure caused by MascotWave typing

### DIFF
--- a/components/footer/MascotWave.tsx
+++ b/components/footer/MascotWave.tsx
@@ -1,14 +1,14 @@
 'use client';
 
 import { motion } from 'framer-motion';
-import type { ComponentProps } from 'react';
+import type { SVGMotionProps } from 'framer-motion';
 
 import { cn } from '@/lib/utils';
 import { usePrefersReducedMotion } from '@/lib/anim';
 
 export type MascotWaveProps = {
   className?: string;
-} & Omit<ComponentProps<'svg'>, 'className'>;
+} & Omit<SVGMotionProps<SVGSVGElement>, 'className'>;
 
 export default function MascotWave({ className, ...props }: MascotWaveProps) {
   const reduced = usePrefersReducedMotion();


### PR DESCRIPTION
## Summary
- update MascotWave's props to extend SVGMotionProps so Framer Motion's event handlers match
- keep the SVG class name override while allowing Framer Motion specific props to pass through

## Testing
- NEXT_PUBLIC_SUPABASE_URL=http://example.com NEXT_PUBLIC_SUPABASE_ANON_KEY=anon CI=1 pnpm build > /tmp/build.log && tail -n 40 /tmp/build.log

------
https://chatgpt.com/codex/tasks/task_e_68cffd357d04833398f17a191952fd47