### PR TITLE
Add SSR-safe theme toggle

### DIFF
--- a/app/(authed)/layout.tsx
+++ b/app/(authed)/layout.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import { BottomNav } from '@/components/BottomNav';
+import ThemeToggle from '@/components/ThemeToggle';
+import { ThemeProvider } from '@/components/ThemeProvider';
 import Footer from '@/components/footer/Footer';
 import { TopAppBar } from '@/components/TopAppBar';
 import { Chip } from '@/components/ui/Chip';
@@ -27,29 +29,34 @@ export default function AuthedLayout({ children }: { children: React.ReactNode }
   }, [pathname]);
 
   return (
-    <div className="flex min-h-screen flex-col bg-paper text-ink">
-      <TopAppBar
-        streakDays={7}
-        onNotificationsClick={() =>
-          push({ title: 'Notifications', description: 'Nothing new yet — keep practicing!', tone: 'info' })
-        }
-        onProfileClick={() => push({ title: 'Profile', description: 'Open your profile to edit details below.', tone: 'info' })}
-      >
-        <Chip tone="secondary" size="sm" className="hidden md:inline-flex">
-          Today’s goal: 10 mins
-        </Chip>
-      </TopAppBar>
-      <main
-        ref={mainRef}
-        id="main-content"
-        tabIndex={-1}
-        className="mx-auto flex w-full max-w-screen-lg flex-1 flex-col gap-8 px-4 py-8 focus:outline-none"
-        role="main"
-      >
-        {children}
-      </main>
-      <Footer />
-      <BottomNav items={NAV_ITEMS} />
-    </div>
+    <ThemeProvider>
+      <div className="flex min-h-screen flex-col bg-paper text-ink">
+        <TopAppBar
+          streakDays={7}
+          onNotificationsClick={() =>
+            push({ title: 'Notifications', description: 'Nothing new yet — keep practicing!', tone: 'info' })
+          }
+          onProfileClick={() => push({ title: 'Profile', description: 'Open your profile to edit details below.', tone: 'info' })}
+        >
+          <div className="flex items-center gap-3">
+            <ThemeToggle />
+            <Chip tone="secondary" size="sm" className="hidden md:inline-flex">
+              Today’s goal: 10 mins
+            </Chip>
+          </div>
+        </TopAppBar>
+        <main
+          ref={mainRef}
+          id="main-content"
+          tabIndex={-1}
+          className="mx-auto flex w-full max-w-screen-lg flex-1 flex-col gap-8 px-4 py-8 focus:outline-none"
+          role="main"
+        >
+          {children}
+        </main>
+        <Footer />
+        <BottomNav items={NAV_ITEMS} />
+      </div>
+    </ThemeProvider>
   );
 }

--- a/app/(public)/layout.tsx
+++ b/app/(public)/layout.tsx
@@ -1,56 +1,64 @@
 import type { ReactNode } from 'react';
 import Link from 'next/link';
+import ThemeToggle from '@/components/ThemeToggle';
+import { ThemeProvider } from '@/components/ThemeProvider';
 import { Button } from '@/components/ui/Button';
 import { InstallPrompt } from '@/components/InstallPrompt';
 import Footer from '@/components/footer/Footer';
 
 export default function PublicLayout({ children }: { children: ReactNode }) {
   return (
-    <div className="flex min-h-screen flex-col bg-paper text-ink">
-      <header
-        className="fixed inset-x-0 top-0 z-40 border-b border-ink/10 bg-paper/95 backdrop-blur supports-[backdrop-filter]:bg-paper/80"
-        role="banner"
-      >
-        <div className="mx-auto flex w-full max-w-screen-lg items-center justify-between gap-6 px-4 py-4">
-          <Link href="/" className="flex items-center gap-3 text-2xl font-serif">
-            <span className="flex h-12 w-12 items-center justify-center rounded-full bg-primary/10 text-3xl" aria-hidden="true">
-              🐢
-            </span>
-            <span>
-              Ìlọ̀
-              <span className="block text-sm font-sans text-ink/60">Yorùbá fun for kids</span>
-            </span>
-          </Link>
-          <nav className="hidden items-center gap-6 text-lg md:flex" aria-label="Public">
-            <Link href="/facts" className="hover:text-primary focus-visible:underline">
-              Fun facts
+    <ThemeProvider>
+      <div className="flex min-h-screen flex-col bg-paper text-ink">
+        <header
+          className="fixed inset-x-0 top-0 z-40 border-b border-ink/10 bg-paper/95 backdrop-blur supports-[backdrop-filter]:bg-paper/80"
+          role="banner"
+        >
+          <div className="mx-auto flex w-full max-w-screen-lg items-center justify-between gap-6 px-4 py-4">
+            <Link href="/" className="flex items-center gap-3 text-2xl font-serif">
+              <span className="flex h-12 w-12 items-center justify-center rounded-full bg-primary/10 text-3xl" aria-hidden="true">
+                🐢
+              </span>
+              <span>
+                Ìlọ̀
+                <span className="block text-sm font-sans text-ink/60">Yorùbá fun for kids</span>
+              </span>
             </Link>
-            <Link href="/install" className="hover:text-primary focus-visible:underline">
-              Install
-            </Link>
-            <Link href="/help" className="hover:text-primary focus-visible:underline">
-              Help
-            </Link>
-          </nav>
-          <div className="flex items-center gap-3">
-            <Link href="/auth/login" className="hidden text-lg font-semibold text-primary underline-offset-4 hover:underline md:inline">
-              Log in
-            </Link>
-            <Button href="/auth/signup" size="md">
-              Get started
-            </Button>
+            <nav className="hidden items-center gap-6 text-lg md:flex" aria-label="Public">
+              <Link href="/facts" className="hover:text-primary focus-visible:underline">
+                Fun facts
+              </Link>
+              <Link href="/install" className="hover:text-primary focus-visible:underline">
+                Install
+              </Link>
+              <Link href="/help" className="hover:text-primary focus-visible:underline">
+                Help
+              </Link>
+            </nav>
+            <div className="flex items-center gap-3">
+              <ThemeToggle />
+              <Link
+                href="/auth/login"
+                className="hidden text-lg font-semibold text-primary underline-offset-4 hover:underline md:inline"
+              >
+                Log in
+              </Link>
+              <Button href="/auth/signup" size="md">
+                Get started
+              </Button>
+            </div>
           </div>
-        </div>
-      </header>
-      <main id="main-content" className="mx-auto w-full max-w-screen-lg flex-1 px-4 pb-10 pt-28 md:pt-32" role="main">
-        {children}
-      </main>
-      <aside className="border-t border-ink/10 bg-paper/95 px-4 py-8">
-        <div className="mx-auto max-w-screen-lg">
-          <InstallPrompt />
-        </div>
-      </aside>
-      <Footer />
-    </div>
+        </header>
+        <main id="main-content" className="mx-auto w-full max-w-screen-lg flex-1 px-4 pb-10 pt-28 md:pt-32" role="main">
+          {children}
+        </main>
+        <aside className="border-t border-ink/10 bg-paper/95 px-4 py-8">
+          <div className="mx-auto max-w-screen-lg">
+            <InstallPrompt />
+          </div>
+        </aside>
+        <Footer />
+      </div>
+    </ThemeProvider>
   );
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import './globals.css';
 import type { Metadata } from 'next';
 import React from 'react';
+import { headers } from 'next/headers';
 import { Noto_Sans, Noto_Serif } from 'next/font/google';
 import { ToastProvider, ToastViewport } from '@/components/ui/Toast';
 
@@ -13,8 +14,11 @@ export const metadata: Metadata = {
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
+  const headerList = headers();
+  const theme = headerList.get('x-ilo-theme');
+
   return (
-    <html lang="en" className={`${sans.variable} ${serif.variable}`}>
+    <html lang="en" className={`${sans.variable} ${serif.variable}`} data-theme={theme ?? undefined}>
       <head>
         <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
       </head>

--- a/components/ThemeProvider.tsx
+++ b/components/ThemeProvider.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import type { ReactNode } from 'react';
+import { Theme, applyTheme } from '@/lib/theme';
+
+type ThemeContextValue = {
+  theme: Theme;
+  setTheme: (theme: Theme) => void;
+};
+
+const ThemeCtx = createContext<ThemeContextValue>({ theme: 'system', setTheme: () => {} });
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [theme, setThemeState] = useState<Theme>('system');
+
+  useEffect(() => {
+    let savedTheme: Theme | null = null;
+    try {
+      const stored = window.localStorage.getItem('ilo-theme');
+      if (stored === 'light' || stored === 'dark' || stored === 'system') {
+        savedTheme = stored;
+      }
+    } catch (error) {
+      savedTheme = null;
+    }
+
+    const initial = savedTheme ?? 'system';
+    applyTheme(initial);
+    setThemeState(initial);
+  }, []);
+
+  useEffect(() => {
+    if (theme !== 'system') return;
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return;
+
+    const media = window.matchMedia('(prefers-color-scheme: dark)');
+    const listener = () => applyTheme('system');
+
+    if (typeof media.addEventListener === 'function') {
+      media.addEventListener('change', listener);
+      return () => media.removeEventListener('change', listener);
+    }
+
+    media.addListener(listener);
+    return () => media.removeListener(listener);
+  }, [theme]);
+
+  const setTheme = useCallback((next: Theme) => {
+    applyTheme(next);
+    setThemeState(next);
+  }, []);
+
+  const value = useMemo(() => ({ theme, setTheme }), [theme, setTheme]);
+
+  return <ThemeCtx.Provider value={value}>{children}</ThemeCtx.Provider>;
+}
+
+export function useTheme() {
+  return useContext(ThemeCtx);
+}

--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import { useTheme } from './ThemeProvider';
+
+const LABELS = {
+  light: 'Light',
+  dark: 'Dark',
+  system: 'Auto',
+} as const;
+
+const ICONS = {
+  light: '☀️',
+  dark: '🌙',
+  system: '🖥️',
+} as const;
+
+export default function ThemeToggle() {
+  const { theme, setTheme } = useTheme();
+  const nextTheme = theme === 'light' ? 'dark' : theme === 'dark' ? 'system' : 'light';
+
+  return (
+    <motion.button
+      type="button"
+      aria-label={`Theme: ${LABELS[theme]}. Activate to switch to ${LABELS[nextTheme]}`}
+      onClick={() => setTheme(nextTheme)}
+      className="inline-flex min-h-[44px] items-center gap-2 rounded-2xl border border-border bg-surface-2 px-4 py-2 text-sm font-medium text-on-surface-2 shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-surface-1"
+      whileTap={{ scale: 0.96 }}
+    >
+      <span aria-hidden="true" className="text-base">
+        {ICONS[theme]}
+      </span>
+      <span>{LABELS[theme]}</span>
+    </motion.button>
+  );
+}

--- a/lib/theme.ts
+++ b/lib/theme.ts
@@ -1,0 +1,41 @@
+export type Theme = 'light' | 'dark' | 'system';
+
+export function getInitialTheme(reqCookie?: string): Theme {
+  if (!reqCookie) return 'system';
+  const match = /(?:^|;\s*)ilo-theme=(dark|light)/.exec(reqCookie);
+  return match ? (match[1] as Theme) : 'system';
+}
+
+export function isDark(theme: Theme): boolean {
+  if (theme === 'dark') return true;
+  if (theme === 'light') return false;
+  if (typeof window !== 'undefined' && typeof window.matchMedia === 'function') {
+    return window.matchMedia('(prefers-color-scheme: dark)').matches;
+  }
+  return false;
+}
+
+export function setThemeCookie(theme: Theme) {
+  if (typeof document === 'undefined') return;
+  const value = theme === 'system' ? '' : theme;
+  document.cookie = `ilo-theme=${value}; Path=/; Max-Age=31536000; SameSite=Lax`;
+}
+
+export function applyTheme(theme: Theme) {
+  if (typeof document === 'undefined') return;
+  const root = document.documentElement;
+
+  if (theme === 'system') {
+    delete root.dataset.theme;
+  } else {
+    root.dataset.theme = theme;
+  }
+
+  try {
+    window.localStorage.setItem('ilo-theme', theme);
+  } catch (error) {
+    // Ignore write errors (e.g., private browsing)
+  }
+
+  setThemeCookie(theme);
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,16 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export function middleware(req: NextRequest) {
+  const res = NextResponse.next();
+  const theme = req.cookies.get('ilo-theme')?.value;
+
+  if (theme === 'dark' || theme === 'light') {
+    res.headers.set('x-ilo-theme', theme);
+  }
+
+  return res;
+}
+
+export const config = {
+  matcher: ['/((?!_next|favicon|icons|manifest).*)'],
+};

--- a/styles/theme.css
+++ b/styles/theme.css
@@ -1,5 +1,5 @@
+/* Light theme defaults */
 :root {
-  /* Base (light) */
   --color-primary: #9c5c2e;
   --on-primary: #ffffff;
   --color-secondary: #4a5b3f;
@@ -23,11 +23,38 @@
   --radius-xl: 1.25rem;
   --font-ui: 'Noto Sans', system-ui, -apple-system, 'Segoe UI', Roboto, 'Apple Color Emoji', 'Segoe UI Emoji';
   --font-title: 'Noto Serif', Georgia, serif;
+
+  color-scheme: light;
 }
 
-/* High-contrast warm dark mode */
+/* Dark theme overrides when explicitly selected */
+:root[data-theme='dark'] {
+  --paper: #12100e;
+  --on-paper: #f5ede0;
+  --surface-1: #171411;
+  --on-surface-1: #f5ede0;
+  --surface-2: #1e1915;
+  --on-surface-2: #efe4d2;
+  --surface-3: #251f19;
+  --on-surface-3: #f2e7d6;
+
+  --color-primary: #b87949;
+  --on-primary: #0e0906;
+  --color-secondary: #5a6c50;
+  --on-secondary: #0e0d0b;
+  --color-accent: #e18b3f;
+  --on-accent: #0e0906;
+
+  --border: rgba(245, 237, 224, 0.16);
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.5);
+  --shadow-md: 0 10px 24px rgba(0, 0, 0, 0.6);
+
+  color-scheme: dark;
+}
+
+/* Respect system preference when no explicit choice was made */
 @media (prefers-color-scheme: dark) {
-  :root {
+  :root:not([data-theme]) {
     --paper: #12100e;
     --on-paper: #f5ede0;
     --surface-1: #171411;
@@ -37,7 +64,6 @@
     --surface-3: #251f19;
     --on-surface-3: #f2e7d6;
 
-    /* Slightly brighter brand hues for dark */
     --color-primary: #b87949;
     --on-primary: #0e0906;
     --color-secondary: #5a6c50;
@@ -48,6 +74,8 @@
     --border: rgba(245, 237, 224, 0.16);
     --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.5);
     --shadow-md: 0 10px 24px rgba(0, 0, 0, 0.6);
+
+    color-scheme: dark;
   }
 }
 
@@ -55,42 +83,55 @@
 .bg-paper {
   background: var(--paper);
 }
+
 .c-on-paper {
   color: var(--on-paper);
 }
+
 .bg-surface-1 {
   background: var(--surface-1);
 }
+
 .c-on-surface-1 {
   color: var(--on-surface-1);
 }
+
 .bg-surface-2 {
   background: var(--surface-2);
 }
+
 .c-on-surface-2 {
   color: var(--on-surface-2);
 }
+
 .bg-surface-3 {
   background: var(--surface-3);
 }
+
 .c-on-surface-3 {
   color: var(--on-surface-3);
 }
+
 .bg-primary {
   background: var(--color-primary);
 }
+
 .c-on-primary {
   color: var(--on-primary);
 }
+
 .bg-secondary {
   background: var(--color-secondary);
 }
+
 .c-on-secondary {
   color: var(--on-secondary);
 }
+
 .bg-accent {
   background: var(--color-accent);
 }
+
 .c-on-accent {
   color: var(--on-accent);
 }
@@ -98,12 +139,15 @@
 .b-border {
   border: 1px solid var(--border);
 }
+
 .r-xl {
   border-radius: var(--radius-xl);
 }
+
 .shadow-sm {
   box-shadow: var(--shadow-sm);
 }
+
 .shadow-md {
   box-shadow: var(--shadow-md);
 }


### PR DESCRIPTION
## Summary
- add theme helpers, provider, and toggle button to control light, dark, and system modes
- wire the theme provider and toggle into public and authed layouts while propagating SSR data-theme hints
- persist theme choice across requests via cookies/localStorage and expose middleware hint for initial render

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d00edb4edc833392233c73da82580f