### PR TITLE
Fix hydration warning from toast portal

### DIFF
--- a/components/ui/Toast.tsx
+++ b/components/ui/Toast.tsx
@@ -4,7 +4,7 @@ import { usePageEnter } from '@/lib/anim';
 import { cn } from '@/lib/utils';
 import { AnimatePresence, motion } from 'framer-motion';
 import type { ReactNode } from 'react';
-import { createContext, useCallback, useContext, useMemo, useState } from 'react';
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import { createPortal } from 'react-dom';
 
 export type ToastTone = 'info' | 'success' | 'error';
@@ -81,8 +81,14 @@ export function useToast() {
 export function ToastViewport() {
   const { toasts, dismiss } = useToast();
   const toastMotion = usePageEnter();
+  const [mounted, setMounted] = useState(false);
 
-  if (typeof document === 'undefined') {
+  useEffect(() => {
+    setMounted(true);
+    return () => setMounted(false);
+  }, []);
+
+  if (!mounted || typeof document === 'undefined') {
     return null;
   }
 


### PR DESCRIPTION
## Summary
- delay rendering the toast viewport portal until the client has mounted to keep the server and client trees in sync

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d02e0781f4833387607a213032a98c