### PR TITLE
Replace emojis with themed icon components

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,10 @@
+require('./eslint-rules/no-emojis-in-ui');
+
 module.exports = {
   parser: '@typescript-eslint/parser',
   extends: ['next/core-web-vitals', 'prettier'],
+  plugins: ['local'],
+  rules: {
+    'local/no-emojis-in-ui': 'warn',
+  },
 };

--- a/app/(authed)/home/page.tsx
+++ b/app/(authed)/home/page.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { Card } from '@/components/ui/Card';
+import Icon from '@/components/icons/Icon';
 import { Button } from '@/components/ui/Button';
+import { Card } from '@/components/ui/Card';
 import { Chip } from '@/components/ui/Chip';
 import { ProgressBar } from '@/components/ui/ProgressBar';
 import { ProgressRing } from '@/components/ui/ProgressRing';
@@ -45,7 +46,8 @@ export default function HomePage() {
         >
           <ProgressRing value={82} label="Goal" />
           <Chip tone="accent" size="md">
-            🔥 12-day streak
+            <Icon name="star" size={16} color="var(--on-accent)" className="shrink-0" aria-hidden />
+            12-day streak
           </Chip>
           <p className="text-center text-lg text-ink/70">Only 8 minutes left to meet today’s goal. Ẹ má ṣe ṣiyemeji!</p>
         </Card>

--- a/app/(authed)/leaderboards/page.tsx
+++ b/app/(authed)/leaderboards/page.tsx
@@ -1,13 +1,14 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import Icon from '@/components/icons/Icon';
+import { Button } from '@/components/ui/Button';
 import { Card } from '@/components/ui/Card';
 import { Chip } from '@/components/ui/Chip';
-import { Select } from '@/components/ui/Select';
-import { Button } from '@/components/ui/Button';
 import { EmptyState } from '@/components/ui/EmptyState';
+import { Select } from '@/components/ui/Select';
 import { usePageEnter } from '@/lib/anim';
 import { motion } from 'framer-motion';
+import { useMemo, useState } from 'react';
 
 interface Entry {
   id: string;
@@ -83,7 +84,7 @@ export default function LeaderboardsPage() {
 
       {data.length === 0 ? (
         <EmptyState
-          icon="📭"
+          icon={<Icon name="help" size={36} color="var(--on-surface-1)" aria-hidden />}
           title="No explorers yet"
           description="Invite kids to start the module to see points roll in."
           action={<Button href="/kids">Add a child</Button>}

--- a/app/(authed)/practice/[lessonId]/page.tsx
+++ b/app/(authed)/practice/[lessonId]/page.tsx
@@ -1,10 +1,11 @@
 'use client';
 
+import Icon from '@/components/icons/Icon';
 import { AudioRecorder } from '@/components/AudioRecorder';
 import { QuizBlock, type QuizItem } from '@/components/QuizBlock';
+import { Button } from '@/components/ui/Button';
 import { Card } from '@/components/ui/Card';
 import { Chip } from '@/components/ui/Chip';
-import { Button } from '@/components/ui/Button';
 import { useToast } from '@/components/ui/Toast';
 import { usePageEnter } from '@/lib/anim';
 import { motion } from 'framer-motion';
@@ -57,11 +58,17 @@ export default function PracticePage({ params }: { params: { lessonId: string } 
           variant={tab === 'pronunciation' ? 'primary' : 'ghost'}
           size="md"
           onClick={() => setTab('pronunciation')}
+          leadingIcon={<Icon name="mic" size={18} />}
         >
-          🎧 Pronunciation
+          Pronunciation
         </Button>
-        <Button variant={tab === 'quiz' ? 'primary' : 'ghost'} size="md" onClick={() => setTab('quiz')}>
-          🎯 Quiz
+        <Button
+          variant={tab === 'quiz' ? 'primary' : 'ghost'}
+          size="md"
+          onClick={() => setTab('quiz')}
+          leadingIcon={<Icon name="practice" size={18} />}
+        >
+          Quiz
         </Button>
       </div>
 

--- a/app/(authed)/profile/page.tsx
+++ b/app/(authed)/profile/page.tsx
@@ -1,17 +1,18 @@
 'use client';
 
-import { useState } from 'react';
+import Icon from '@/components/icons/Icon';
+import { AvatarPicker } from '@/components/AvatarPicker';
+import { Button } from '@/components/ui/Button';
 import { Card } from '@/components/ui/Card';
 import { Chip } from '@/components/ui/Chip';
-import { Button } from '@/components/ui/Button';
-import { Modal } from '@/components/ui/Modal';
 import { Input } from '@/components/ui/Input';
-import { Select } from '@/components/ui/Select';
+import { Modal } from '@/components/ui/Modal';
 import { ProgressRing } from '@/components/ui/ProgressRing';
-import { AvatarPicker } from '@/components/AvatarPicker';
+import { Select } from '@/components/ui/Select';
 import { useToast } from '@/components/ui/Toast';
 import { usePageEnter } from '@/lib/anim';
 import { motion } from 'framer-motion';
+import { useState } from 'react';
 
 export default function ProfilePage() {
   const [profile, setProfile] = useState({ name: 'Mama Adé', country: 'NG', avatar: 'sunny-tortoise' });
@@ -63,7 +64,8 @@ export default function ProfilePage() {
           <ProgressRing value={68} label="XP" />
           <p className="text-lg text-ink/70">Total XP: 1,250</p>
           <Chip tone="accent" size="md">
-            🔥 12-day streak
+            <Icon name="star" size={16} color="var(--on-accent)" className="shrink-0" aria-hidden />
+            12-day streak
           </Chip>
         </Card>
       </section>

--- a/app/(authed)/quiz/[lessonId]/page.tsx
+++ b/app/(authed)/quiz/[lessonId]/page.tsx
@@ -64,7 +64,7 @@ export default function QuizPage({ params }: { params: { lessonId: string } }) {
           onComplete={(score) => {
             if (!lesson) return;
             if (score === 100) {
-              push({ title: '🎉 Perfect score!', description: 'Your answers are all correct.', tone: 'success' });
+              push({ title: 'Perfect score!', description: 'Your answers are all correct.', tone: 'success' });
             } else {
               push({ title: 'Nice work!', description: `You scored ${score}%. Keep practicing.`, tone: 'info' });
             }

--- a/app/(public)/facts/page.tsx
+++ b/app/(public)/facts/page.tsx
@@ -1,16 +1,18 @@
 'use client';
 
+import Icon from '@/components/icons/Icon';
+import type { IconName } from '@/components/icons/icons';
+import { Button } from '@/components/ui/Button';
 import { Card } from '@/components/ui/Card';
 import { Chip } from '@/components/ui/Chip';
 import { Modal } from '@/components/ui/Modal';
-import { Button } from '@/components/ui/Button';
 import { usePageEnter } from '@/lib/anim';
 import { motion } from 'framer-motion';
 import { useState } from 'react';
 
 type Fact = {
   id: string;
-  emoji: string;
+  icon: IconName;
   title: string;
   summary: string;
   content: string;
@@ -19,7 +21,7 @@ type Fact = {
 const FACTS: Fact[] = [
   {
     id: 'drums',
-    emoji: '🥁',
+    icon: 'party',
     title: 'Talking drums speak Yorùbá tones',
     summary: 'Gángan drums can mimic speech—players match rising and falling tones to send messages.',
     content:
@@ -27,7 +29,7 @@ const FACTS: Fact[] = [
   },
   {
     id: 'tortoise',
-    emoji: '🐢',
+    icon: 'tortoise',
     title: 'Ijapa the storyteller',
     summary: 'The clever tortoise appears in folktales teaching patience, respect, and wit.',
     content:
@@ -35,7 +37,7 @@ const FACTS: Fact[] = [
   },
   {
     id: 'greetings',
-    emoji: '🌅',
+    icon: 'globe',
     title: 'Greetings change with the time of day',
     summary: 'Ẹ káàárọ̀ (good morning) becomes Ẹ káàsán (good afternoon) and Ẹ káalẹ́ (good evening).',
     content:
@@ -64,9 +66,7 @@ export default function FactsPage() {
             bodyClassName="space-y-4"
             header={
               <span className="flex items-center gap-3 text-xl font-serif">
-                <span className="text-3xl" aria-hidden="true">
-                  {fact.emoji}
-                </span>
+                <Icon name={fact.icon} size={28} color="var(--on-surface-1)" className="shrink-0" aria-hidden />
                 {fact.title}
               </span>
             }

--- a/app/(public)/layout.tsx
+++ b/app/(public)/layout.tsx
@@ -1,10 +1,11 @@
-import type { ReactNode } from 'react';
-import Link from 'next/link';
+import Icon from '@/components/icons/Icon';
 import ThemeToggle from '@/components/ThemeToggle';
 import { ThemeProvider } from '@/components/ThemeProvider';
 import { Button } from '@/components/ui/Button';
 import { InstallPrompt } from '@/components/InstallPrompt';
 import Footer from '@/components/footer/Footer';
+import Link from 'next/link';
+import type { ReactNode } from 'react';
 
 export default function PublicLayout({ children }: { children: ReactNode }) {
   return (
@@ -16,8 +17,11 @@ export default function PublicLayout({ children }: { children: ReactNode }) {
         >
           <div className="mx-auto flex w-full max-w-screen-lg items-center justify-between gap-6 px-4 py-4">
             <Link href="/" className="flex items-center gap-3 text-2xl font-serif">
-              <span className="flex h-12 w-12 items-center justify-center rounded-full bg-primary/10 text-3xl" aria-hidden="true">
-                🐢
+              <span
+                className="flex h-12 w-12 items-center justify-center rounded-full bg-primary/10 text-[var(--color-primary)]"
+                aria-hidden="true"
+              >
+                <Icon name="tortoise" size={28} color="var(--color-primary)" />
               </span>
               <span>
                 Ìlọ̀

--- a/app/(public)/page.tsx
+++ b/app/(public)/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import type { IconName } from '@/components/icons/icons';
 import { FeatureCard } from '@/components/feature-card';
 import { Button } from '@/components/ui/Button';
 import { Card } from '@/components/ui/Card';
@@ -7,21 +8,21 @@ import { Chip } from '@/components/ui/Chip';
 import { usePageEnter } from '@/lib/anim';
 import { motion } from 'framer-motion';
 
-const FEATURES = [
+const FEATURES: Array<{ title: string; body: string; icon: IconName }> = [
   {
     title: 'Lessons that feel like play',
     body: 'Ọmọde kọ ẹ̀kọ́ pẹ̀lú fọ́nran, orin, àti ìtàn Ayélújára. Short bursts keep focus and joy.',
-    icon: '📚',
+    icon: 'books',
   },
   {
     title: 'Quizzes & badges',
     body: 'Earn tortoise shells for each challenge. Immediate feedback says “Ẹ ṣe!” when you nail it.',
-    icon: '🎉',
+    icon: 'party',
   },
   {
     title: 'Culture stories',
     body: 'Hear elders share proverbs and pro-tips about everyday Yorùbá life.',
-    icon: '🐢',
+    icon: 'tortoise',
   },
 ];
 

--- a/components/AudioRecorder.tsx
+++ b/components/AudioRecorder.tsx
@@ -200,7 +200,7 @@ export function AudioRecorder({ lessonId, onSubmit, className }: AudioRecorderPr
       await queueRecording(entry);
       await refreshQueuedCount();
       push({
-        title: '📶 Saved offline — will upload when online.',
+        title: 'Saved offline — will upload when online.',
         description: 'We’ll send your practice as soon as you’re connected.',
         tone: 'info',
       });
@@ -216,7 +216,7 @@ export function AudioRecorder({ lessonId, onSubmit, className }: AudioRecorderPr
       setSubmitting(true);
       await onSubmit(recordedBlob);
       push({
-        title: 'Great effort! 🎧',
+        title: 'Great effort!',
         description: 'Your pronunciation is on its way to your mentor.',
         tone: 'success',
       });

--- a/components/InstallPrompt.tsx
+++ b/components/InstallPrompt.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Icon from '@/components/icons/Icon';
 import { Button } from '@/components/ui/Button';
 import { Card } from '@/components/ui/Card';
 import { useCardPop, usePrefersReducedMotion } from '@/lib/anim';
@@ -67,8 +68,11 @@ export function InstallPrompt() {
       <motion.div {...(!reduced ? cardMotion : {})}>
         <Card className="max-w-xl">
           <div className="flex flex-col gap-4 md:flex-row md:items-center">
-            <div className="flex h-28 w-28 items-center justify-center rounded-full bg-primary/10 text-4xl" aria-hidden="true">
-              🐢
+            <div
+              className="flex h-28 w-28 items-center justify-center rounded-full bg-primary/10 text-[var(--color-primary)]"
+              aria-hidden="true"
+            >
+              <Icon name="tortoise" size={48} color="var(--color-primary)" />
             </div>
             <div className="space-y-2 text-left">
               <h3 className="text-2xl font-serif">Install Ìlọ̀ for quick learning</h3>

--- a/components/QuizBlock.tsx
+++ b/components/QuizBlock.tsx
@@ -64,7 +64,7 @@ export function QuizBlock({ items, className, onComplete }: QuizBlockProps) {
     setSubmitted(true);
     onComplete?.(calculatedScore);
     push({
-      title: calculatedScore === 100 ? 'Fantastìkì! 🎉' : 'Ìdáhùn rẹ̀ ti dé',
+      title: calculatedScore === 100 ? 'Fantastìkì!' : 'Ìdáhùn rẹ̀ ti dé',
       description:
         calculatedScore === 100
           ? 'O ṣe aṣeyọrí pipe — ẹ̀ kí o!'
@@ -157,7 +157,7 @@ export function QuizBlock({ items, className, onComplete }: QuizBlockProps) {
                     id={`${idPrefix}-${item.id}-input`}
                     value={responses[item.id] ?? ''}
                     onChange={(event) => handleSelect(item.id, event.target.value)}
-                    helperText={submitted ? (feedback ? 'Ìbáṣepọ̀! 🎉' : 'Ṣe àtúnṣe kí o ṣàṣeyọrí.') : item.hint}
+                    helperText={submitted ? (feedback ? 'Ìbáṣepọ̀!' : 'Ṣe àtúnṣe kí o ṣàṣeyọrí.') : item.hint}
                     aria-describedby={submitted ? `${idPrefix}-${item.id}-feedback` : undefined}
                   />
                   <ToneKeypad targetId={`${idPrefix}-${item.id}-input`} />

--- a/components/StreakCounter.tsx
+++ b/components/StreakCounter.tsx
@@ -1,5 +1,11 @@
+import Icon from '@/components/icons/Icon';
 import React from 'react';
 
 export default function StreakCounter({ days }: { days: number }) {
-  return <div aria-label="Streak">🔥 {days} day streak</div>;
+  return (
+    <div aria-label="Streak" className="inline-flex items-center gap-1">
+      <Icon name="star" size={16} aria-hidden />
+      {days} day streak
+    </div>
+  );
 }

--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import Icon from '@/components/icons/Icon';
+import type { IconName } from '@/components/icons/icons';
 import { motion } from 'framer-motion';
 import { useTheme } from './ThemeProvider';
 
@@ -9,11 +11,11 @@ const LABELS = {
   system: 'Auto',
 } as const;
 
-const ICONS = {
-  light: '☀️',
-  dark: '🌙',
-  system: '🖥️',
-} as const;
+const ICONS: Record<'light' | 'dark' | 'system', IconName> = {
+  light: 'star',
+  dark: 'shield',
+  system: 'globe',
+};
 
 export default function ThemeToggle() {
   const { theme, setTheme } = useTheme();
@@ -27,9 +29,13 @@ export default function ThemeToggle() {
       className="inline-flex min-h-[44px] items-center gap-2 rounded-2xl border border-border bg-surface-2 px-4 py-2 text-sm font-medium text-on-surface-2 shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-surface-1"
       whileTap={{ scale: 0.96 }}
     >
-      <span aria-hidden="true" className="text-base">
-        {ICONS[theme]}
-      </span>
+      <Icon
+        name={ICONS[theme]}
+        size={18}
+        color="var(--on-surface-2)"
+        className="inline-flex"
+        aria-hidden
+      />
       <span>{LABELS[theme]}</span>
     </motion.button>
   );

--- a/components/TopAppBar.tsx
+++ b/components/TopAppBar.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Icon from '@/components/icons/Icon';
 import { Button } from '@/components/ui/Button';
 import { Chip } from '@/components/ui/Chip';
 import { cn } from '@/lib/utils';
@@ -42,8 +43,8 @@ export function TopAppBar({
             <Menu className="h-6 w-6" aria-hidden="true" />
           </button>
           <Link href="/home" className="flex items-center gap-3 text-2xl font-serif text-ink">
-            <span className="flex h-12 w-12 items-center justify-center rounded-full bg-primary/10 text-3xl" aria-hidden="true">
-              🐢
+            <span className="flex h-12 w-12 items-center justify-center rounded-full bg-primary/10 text-[var(--color-primary)]" aria-hidden="true">
+              <Icon name="tortoise" size={28} />
             </span>
             <span className="leading-none">
               Ìlọ̀
@@ -55,7 +56,8 @@ export function TopAppBar({
           {children}
           {typeof streakDays === 'number' ? (
             <Chip tone="accent" size="sm">
-              🔥 {streakDays} day streak
+              <Icon name="star" size={14} color="var(--on-accent)" className="shrink-0" />
+              {streakDays} day streak
             </Chip>
           ) : null}
           <Button

--- a/components/feature-card.tsx
+++ b/components/feature-card.tsx
@@ -1,5 +1,8 @@
+import Icon from '@/components/icons/Icon';
+import type { IconName } from '@/components/icons/icons';
+
 interface FeatureCardProps {
-  icon: string;
+  icon: IconName;
   title: string;
   body: string;
 }
@@ -8,9 +11,7 @@ export function FeatureCard({ icon, title, body }: FeatureCardProps) {
   return (
     <div className="bg-surface-1 c-on-surface-1 r-xl b-border shadow-md p-4 md:p-5 transition hover:bg-[var(--surface-3)]">
       <div className="flex items-start gap-3">
-        <div className="text-2xl md:text-3xl" aria-hidden="true">
-          {icon}
-        </div>
+        <Icon name={icon} size={28} color="var(--on-surface-1)" className="text-2xl md:text-3xl" aria-hidden />
         <div className="space-y-1">
           <h3 className="font-title text-xl md:text-2xl text-[var(--on-surface-1)]">{title}</h3>
           <p className="text-[var(--on-surface-1)]/85">{body}</p>

--- a/components/features-grid.tsx
+++ b/components/features-grid.tsx
@@ -1,15 +1,20 @@
 import { FeatureCard } from '@/components/feature-card';
+import type { IconName } from '@/components/icons/icons';
 
-const features = [
+const features: Array<{ icon: IconName; title: string; body: string }> = [
   {
-    icon: '😊',
+    icon: 'kids',
     title: 'Cartoon Guides',
     body: 'Meet Funmiláyọ̀, Ọládélé, and friends—your cheerful guides through greetings, numbers, and proverbs.',
   },
-  { icon: '🔊', title: 'Tap-to-Hear', body: 'Hear perfect tones. Practice with a tap.' },
-  { icon: '🎤', title: 'Voice Challenges', body: 'Record yourself. Get instant feedback.' },
-  { icon: '🌞', title: 'Culture Spotlight', body: 'Proverbs, songs, and celebrations woven into every module.' },
-  { icon: '💬', title: 'WhatsApp Easy-Teach', body: 'Teachers upload lessons by sending a voice note. Ìlọ̀ does the rest.' },
+  { icon: 'practice', title: 'Tap-to-Hear', body: 'Hear perfect tones. Practice with a tap.' },
+  { icon: 'mic', title: 'Voice Challenges', body: 'Record yourself. Get instant feedback.' },
+  { icon: 'globe', title: 'Culture Spotlight', body: 'Proverbs, songs, and celebrations woven into every module.' },
+  {
+    icon: 'mail',
+    title: 'WhatsApp Easy-Teach',
+    body: 'Teachers upload lessons by sending a voice note. Ìlọ̀ does the rest.',
+  },
 ];
 
 export default function FeaturesGrid() {

--- a/components/footer/FooterSections.tsx
+++ b/components/footer/FooterSections.tsx
@@ -1,15 +1,15 @@
 'use client';
 
-import { motion } from 'framer-motion';
-import Link from 'next/link';
-import { useCallback, useMemo, useState, type ComponentType } from 'react';
-
+import Icon from '@/components/icons/Icon';
 import { Button } from '@/components/ui/Button';
 import { Input } from '@/components/ui/Input';
+import { useToast } from '@/components/ui/Toast';
 import { useCardPop, usePrefersReducedMotion } from '@/lib/anim';
 import type { FooterModel, FooterProgress } from '@/lib/footerContext';
 import { cn } from '@/lib/utils';
-import { useToast } from '@/components/ui/Toast';
+import { motion } from 'framer-motion';
+import Link from 'next/link';
+import { useCallback, useMemo, useState, type ComponentType } from 'react';
 
 type MascotComponent = ComponentType<{ className?: string }>;
 
@@ -28,7 +28,10 @@ export function GreetingBar({ greeting, childName, Mascot }: GreetingBarProps) {
         <Mascot className="h-10 w-10" />
         <div className="space-y-1">
           <p className="text-sm font-semibold uppercase tracking-wide text-[var(--on-surface-2)]/70">Friendly tortoise</p>
-          <p className="text-2xl font-serif leading-snug">{welcomeLine} <span aria-hidden="true">👋</span></p>
+          <p className="text-2xl font-serif leading-snug">
+            {welcomeLine}{' '}
+            <Icon name="party" size={20} color="var(--on-surface-2)" className="inline-flex align-middle" aria-hidden />
+          </p>
         </div>
       </div>
       <p className="text-base text-[var(--on-surface-2)]/80">
@@ -52,16 +55,16 @@ export function PrimaryCta({ cta }: { cta?: FooterModel['primaryCta'] }) {
           Ready for a playful boost? Tap the big button below to keep learning.
         </p>
         {cta ? (
-          <Button href={cta.href} size="xl" className="w-full justify-between">
-            <span className="flex items-center gap-2">
-              {cta.icon ? (
-                <span aria-hidden="true" className="text-2xl">
-                  {cta.icon}
-                </span>
-              ) : null}
-              <span>{cta.label}</span>
-            </span>
-            <span aria-hidden="true">→</span>
+          <Button
+            href={cta.href}
+            size="xl"
+            className="w-full justify-between"
+            leadingIcon={
+              cta.icon ? <Icon name={cta.icon} size={22} color="var(--on-primary)" className="shrink-0" /> : undefined
+            }
+            trailingIcon={<Icon name="chevron-right" size={18} color="var(--on-primary)" className="shrink-0" />}
+          >
+            {cta.label}
           </Button>
         ) : (
           <div className="flex min-h-[56px] items-center justify-center rounded-2xl border border-dashed border-[var(--on-surface-2)]/25 px-4 text-lg text-[var(--on-surface-2)]/70">
@@ -96,8 +99,8 @@ export function FunFactCard({ data }: { data?: FooterModel['funFact'] }) {
           href={data?.href ?? '/facts'}
           className="inline-flex min-h-[44px] items-center gap-2 rounded-2xl bg-secondary px-4 py-2 text-lg font-semibold c-on-secondary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--surface-2)]"
         >
-          Read the full fact
-          <span aria-hidden="true">🌿</span>
+          <span>Read the full fact</span>
+          <Icon name="books" size={18} color="var(--on-secondary)" className="shrink-0" aria-hidden />
         </Link>
       </div>
     </motion.div>
@@ -321,7 +324,7 @@ export function StatusPills({ offline, showInstall, onInstallClick, installHref 
     <div className="flex flex-wrap gap-2" aria-live="polite">
       {offline ? (
         <span className="inline-flex min-h-[40px] items-center gap-2 rounded-full bg-secondary px-4 text-sm font-semibold c-on-secondary">
-          <span aria-hidden="true">📡</span>
+          <Icon name="globe" size={16} color="var(--on-secondary)" className="shrink-0" aria-hidden />
           Offline — changes will sync
         </span>
       ) : null}
@@ -332,7 +335,7 @@ export function StatusPills({ offline, showInstall, onInstallClick, installHref 
             onClick={onInstallClick}
             className="inline-flex min-h-[40px] items-center gap-2 rounded-full bg-primary px-4 text-sm font-semibold c-on-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--surface-1)]"
           >
-            <span aria-hidden="true">📲</span>
+            <Icon name="install" size={18} color="var(--on-primary)" className="shrink-0" aria-hidden />
             Install Ìlọ̀
           </button>
         ) : (
@@ -340,7 +343,7 @@ export function StatusPills({ offline, showInstall, onInstallClick, installHref 
             href={installHref}
             className="inline-flex min-h-[40px] items-center gap-2 rounded-full bg-primary px-4 text-sm font-semibold c-on-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--surface-1)]"
           >
-            <span aria-hidden="true">📲</span>
+            <Icon name="install" size={18} color="var(--on-primary)" className="shrink-0" aria-hidden />
             Install Ìlọ̀
           </Link>
         )

--- a/components/icons/Icon.tsx
+++ b/components/icons/Icon.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import { Icons, type IconName, type IconSvgProps } from './icons';
+
+type IconProps = {
+  name: IconName;
+  size?: number;
+  title?: string;
+  className?: string;
+  color?: string;
+  'data-color'?: IconSvgProps['data-color'];
+} & Omit<React.HTMLAttributes<HTMLSpanElement>, 'color'>;
+
+export default function Icon({
+  name,
+  size = 24,
+  title,
+  className,
+  color = 'currentColor',
+  'data-color': dataColor,
+  ...spanProps
+}: IconProps) {
+  const SvgIcon = Icons[name];
+  return (
+    <span className={className} style={{ color }} {...spanProps}>
+      <SvgIcon size={size} title={title} data-color={dataColor} />
+    </span>
+  );
+}

--- a/components/icons/IconButton.tsx
+++ b/components/icons/IconButton.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import Icon from './Icon';
+
+export default function IconButton({
+  name,
+  onClick,
+  label,
+}: {
+  name: import('./icons').IconName;
+  onClick?: () => void;
+  label: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={label}
+      className="inline-flex h-11 w-11 items-center justify-center rounded-2xl border border-[var(--border)] bg-surface-2 text-[var(--on-surface-2)] shadow-sm transition focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--surface-1)]"
+    >
+      <Icon name={name} size={20} />
+    </button>
+  );
+}

--- a/components/icons/icons.tsx
+++ b/components/icons/icons.tsx
@@ -1,0 +1,186 @@
+import * as React from 'react';
+
+export type IconName =
+  | 'books'
+  | 'party'
+  | 'tortoise'
+  | 'mic'
+  | 'badge'
+  | 'play'
+  | 'chevron-right'
+  | 'chevron-left'
+  | 'star'
+  | 'shield'
+  | 'globe'
+  | 'mail'
+  | 'install'
+  | 'leaderboard'
+  | 'lesson'
+  | 'practice'
+  | 'profile'
+  | 'kids'
+  | 'help';
+
+type IconColor =
+  | 'ink'
+  | 'primary'
+  | 'secondary'
+  | 'accent'
+  | 'on-surface-1'
+  | 'on-paper';
+
+export type IconSvgProps = React.SVGProps<SVGSVGElement> & {
+  size?: number;
+  title?: string;
+  'data-color'?: IconColor;
+};
+
+function Svg({ title, size, children, ...rest }: IconSvgProps & { children: React.ReactNode }) {
+  const svgProps: React.SVGProps<SVGSVGElement> = {
+    width: size ?? 24,
+    height: size ?? 24,
+    viewBox: '0 0 24 24',
+    role: 'img',
+    'aria-hidden': title ? undefined : true,
+    focusable: false,
+    ...rest,
+  };
+
+  return (
+    <svg {...svgProps}>
+      {title ? <title>{title}</title> : null}
+      {children}
+    </svg>
+  );
+}
+
+export const Icons: Record<IconName, (props: IconSvgProps) => JSX.Element> = {
+  tortoise: (props) => (
+    <Svg {...props}>
+      <path
+        fill="currentColor"
+        d="M4 13c0-3.5 3.2-6.5 8-6.5 3.9 0 7 2.2 7.7 5.1l1.3.4a1 1 0 0 1 .7 1.2l-.2 1a1 1 0 0 1-1 .8h-1.6a3 3 0 0 1-2.8 2H12a3 3 0 0 1-2.8-2H7.3a3.3 3.3 0 0 1-3.3-3Z"
+      />
+      <circle cx="11" cy="10.5" r="0.9" fill="currentColor" />
+    </Svg>
+  ),
+  books: (props) => (
+    <Svg {...props}>
+      <path fill="currentColor" d="M5 4h6a2 2 0 0 1 2 2v12H7a2 2 0 0 1-2-2V4Zm8 0h6v12a2 2 0 0 1-2 2h-6V6a2 2 0 0 1 2-2Z" />
+      <path fill="currentColor" d="M7 6h4v1H7zM15 6h4v1h-4z" />
+    </Svg>
+  ),
+  party: (props) => (
+    <Svg {...props}>
+      <path fill="currentColor" d="M3 20l4.5-10L17 19 3 20Z" />
+      <path fill="currentColor" d="M10 4c2 0 3 1 3 3" />
+      <circle cx="18" cy="6" r="1.5" fill="currentColor" />
+    </Svg>
+  ),
+  mic: (props) => (
+    <Svg {...props}>
+      <rect x="9" y="3" width="6" height="10" rx="3" fill="currentColor" />
+      <path d="M6 10v1a6 6 0 0 0 12 0v-1" stroke="currentColor" strokeWidth="1.5" fill="none" />
+      <path d="M12 17v3" stroke="currentColor" strokeWidth="1.5" />
+    </Svg>
+  ),
+  badge: (props) => (
+    <Svg {...props}>
+      <circle cx="12" cy="12" r="7" fill="currentColor" />
+      <path
+        d="M12 8l1.6 3.3 3.6.3-2.7 2.3.8 3.5-3.3-1.8-3.3 1.8.8-3.5L6.8 11.6l3.6-.3L12 8z"
+        fill="var(--paper)"
+      />
+    </Svg>
+  ),
+  play: (props) => (
+    <Svg {...props}>
+      <path d="M8 6l9 6-9 6V6z" fill="currentColor" />
+    </Svg>
+  ),
+  'chevron-right': (props) => (
+    <Svg {...props}>
+      <path d="M9 6l6 6-6 6" fill="none" stroke="currentColor" strokeWidth="2" />
+    </Svg>
+  ),
+  'chevron-left': (props) => (
+    <Svg {...props}>
+      <path d="M15 6l-6 6 6 6" fill="none" stroke="currentColor" strokeWidth="2" />
+    </Svg>
+  ),
+  star: (props) => (
+    <Svg {...props}>
+      <path
+        d="M12 3l2.7 5.6 6.2.9-4.5 4.3 1.1 6.1L12 17l-5.5 2.9 1.1-6.1L3 9.5l6.2-.9L12 3z"
+        fill="currentColor"
+      />
+    </Svg>
+  ),
+  shield: (props) => (
+    <Svg {...props}>
+      <path d="M12 3l7 3v5c0 4.4-3.2 8.4-7 9-3.8-.6-7-4.6-7-9V6l7-3z" fill="currentColor" />
+    </Svg>
+  ),
+  globe: (props) => (
+    <Svg {...props}>
+      <circle cx="12" cy="12" r="9" stroke="currentColor" strokeWidth="1.5" fill="none" />
+      <path d="M3 12h18M12 3a12 12 0 0 1 0 18M12 3a12 12 0 0 0 0 18" stroke="currentColor" strokeWidth="1" />
+    </Svg>
+  ),
+  mail: (props) => (
+    <Svg {...props}>
+      <rect x="3" y="5" width="18" height="14" rx="2" fill="currentColor" />
+      <path d="M3 7l9 6 9-6" stroke="var(--paper)" strokeWidth="1.2" fill="none" />
+    </Svg>
+  ),
+  install: (props) => (
+    <Svg {...props}>
+      <path d="M12 3v9" stroke="currentColor" strokeWidth="2" />
+      <path d="M8 8l4 4 4-4" stroke="currentColor" strokeWidth="2" fill="none" />
+      <rect x="5" y="13" width="14" height="8" rx="2" fill="currentColor" />
+    </Svg>
+  ),
+  leaderboard: (props) => (
+    <Svg {...props}>
+      <rect x="3" y="12" width="4" height="7" rx="1" fill="currentColor" />
+      <rect x="10" y="7" width="4" height="12" rx="1" fill="currentColor" />
+      <rect x="17" y="10" width="4" height="9" rx="1" fill="currentColor" />
+    </Svg>
+  ),
+  lesson: (props) => (
+    <Svg {...props}>
+      <path d="M6 4h10a2 2 0 0 1 2 2v12H8a2 2 0 0 1-2-2V4z" fill="currentColor" />
+      <path d="M8 7h8M8 10h8" stroke="var(--paper)" />
+    </Svg>
+  ),
+  practice: (props) => (
+    <Svg {...props}>
+      <circle cx="12" cy="12" r="9" stroke="currentColor" strokeWidth="1.5" fill="none" />
+      <path d="M8 14l3-4 2 2 3-4" stroke="currentColor" strokeWidth="1.5" fill="none" />
+    </Svg>
+  ),
+  profile: (props) => (
+    <Svg {...props}>
+      <circle cx="12" cy="9" r="3" fill="currentColor" />
+      <path d="M5 19a7 7 0 0 1 14 0" stroke="currentColor" strokeWidth="1.5" fill="none" />
+    </Svg>
+  ),
+  kids: (props) => (
+    <Svg {...props}>
+      <circle cx="9" cy="10" r="2.5" fill="currentColor" />
+      <circle cx="15" cy="10" r="2.5" fill="currentColor" />
+      <path d="M5 18a7 7 0 0 1 14 0" stroke="currentColor" strokeWidth="1.5" fill="none" />
+    </Svg>
+  ),
+  help: (props) => (
+    <Svg {...props}>
+      <path d="M12 18h.01" stroke="currentColor" strokeWidth="2" />
+      <path
+        d="M9.1 9a3 3 0 1 1 5.8 1c0 1.4-1.5 1.9-2.1 2.6-.3.3-.4.7-.4 1.4"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        fill="none"
+      />
+    </Svg>
+  ),
+};

--- a/components/ui/Toast.tsx
+++ b/components/ui/Toast.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import Icon from '@/components/icons/Icon';
+import type { IconName } from '@/components/icons/icons';
 import { usePageEnter } from '@/lib/anim';
 import { cn } from '@/lib/utils';
 import { AnimatePresence, motion } from 'framer-motion';
@@ -35,10 +37,10 @@ const toneStyles: Record<ToastTone, string> = {
   error: 'border-red-400/60 bg-red-50 text-red-900',
 };
 
-const toneIcon: Record<ToastTone, string> = {
-  info: '⭐️',
-  success: '🎉',
-  error: '⚠️',
+const toneIcon: Record<ToastTone, IconName> = {
+  info: 'star',
+  success: 'party',
+  error: 'shield',
 };
 
 export function ToastProvider({ children }: { children: ReactNode }) {
@@ -107,9 +109,13 @@ export function ToastViewport() {
             )}
           >
             <div className="flex items-start gap-3">
-              <span aria-hidden="true" className="text-2xl">
-                {toneIcon[toast.tone ?? 'info']}
-              </span>
+              <Icon
+                name={toneIcon[toast.tone ?? 'info']}
+                size={24}
+                color="currentColor"
+                className="text-2xl"
+                aria-hidden
+              />
               <div className="flex-1 space-y-1">
                 <p className="font-semibold text-lg">{toast.title}</p>
                 {toast.description ? <p className="text-base text-ink/70">{toast.description}</p> : null}

--- a/eslint-plugin-local/index.js
+++ b/eslint-plugin-local/index.js
@@ -1,0 +1,7 @@
+const path = require('path');
+
+module.exports = {
+  rules: {
+    'no-emojis-in-ui': require(path.join(process.cwd(), 'eslint-rules/no-emojis-in-ui')),
+  },
+};

--- a/eslint-plugin-local/package.json
+++ b/eslint-plugin-local/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "eslint-plugin-local",
+  "version": "1.0.0",
+  "main": "index.js"
+}

--- a/eslint-rules/no-emojis-in-ui.js
+++ b/eslint-rules/no-emojis-in-ui.js
@@ -1,0 +1,31 @@
+/**
+ * Flags emoji characters in JSX text/strings to enforce using <Icon/> instead.
+ * Lightweight regex; no native addons.
+ */
+const EMOJI_RE = /[\u{1F300}-\u{1F5FF}\u{1F600}-\u{1F64F}\u{1F680}-\u{1F6FF}\u{1F700}-\u{1F77F}\u{1F780}-\u{1F7FF}\u{1F800}-\u{1F8FF}\u{1F900}-\u{1F9FF}\u{1FA70}-\u{1FAFF}\u{1FB00}-\u{1FBFF}\u{2600}-\u{26FF}\u{2700}-\u{27BF}\uFE0F]/u;
+
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: { description: 'Disallow emojis in UI strings; use <Icon/> instead.' },
+    schema: [],
+  },
+  create(ctx) {
+    function check(node, value) {
+      if (typeof value === 'string' && EMOJI_RE.test(value)) {
+        ctx.report({ node, message: 'Replace emoji with themed <Icon /> component.' });
+      }
+    }
+    return {
+      Literal(node) {
+        check(node, node.raw ?? node.value);
+      },
+      TemplateElement(node) {
+        check(node, node.value.raw);
+      },
+      JSXText(node) {
+        check(node, node.value);
+      },
+    };
+  },
+};

--- a/lib/footerContext.ts
+++ b/lib/footerContext.ts
@@ -1,3 +1,4 @@
+import type { IconName } from '@/components/icons/icons';
 import type { SupabaseClient } from '@supabase/supabase-js';
 
 export type FooterRouteKind =
@@ -12,7 +13,7 @@ export type FooterRouteKind =
 export type FooterModel = {
   greeting: string;
   routeKind: FooterRouteKind;
-  primaryCta?: { href: string; label: string; icon?: string };
+  primaryCta?: { href: string; label: string; icon?: IconName };
   secondaryLinks: { href: string; label: string }[];
   funFact?: { id: string; title: string; teaser: string; href: string };
   nextLesson?: { id: string; title: string; href: string } | null;
@@ -263,13 +264,13 @@ export async function getFooterModel({
   let primaryCta: FooterModel['primaryCta'];
   switch (routeKind) {
     case 'landing':
-      primaryCta = { href: '/auth/signup', label: 'Get started', icon: '✨' };
+      primaryCta = { href: '/auth/signup', label: 'Get started', icon: 'star' };
       break;
     case 'lesson':
       primaryCta = {
         href: progress?.currentLessonId ? `/practice/${progress.currentLessonId}` : '/practice/intro',
         label: 'Keep practicing',
-        icon: '🎧',
+        icon: 'practice',
       };
       break;
     case 'practice':
@@ -277,36 +278,36 @@ export async function getFooterModel({
         primaryCta = {
           href: progress.currentLessonId ? `/quiz/${progress.currentLessonId}` : '/quiz/intro',
           label: 'Review mistakes',
-          icon: '🔍',
+          icon: 'lesson',
         };
       } else if (progress?.currentLessonId) {
         primaryCta = {
           href: `/practice/${progress.currentLessonId}`,
           label: 'Record again',
-          icon: '🎙️',
+          icon: 'mic',
         };
       } else {
-        primaryCta = { href: '/quiz/intro', label: 'Try a quiz', icon: '🎯' };
+        primaryCta = { href: '/quiz/intro', label: 'Try a quiz', icon: 'play' };
       }
       break;
     case 'leaderboard':
       primaryCta = {
         href: progress?.currentLessonId ? `/practice/${progress.currentLessonId}` : '/practice/intro',
         label: 'Practice now',
-        icon: '💪',
+        icon: 'leaderboard',
       };
       break;
     case 'profile':
     case 'kids':
       if (childName) {
-        primaryCta = { href: '/kids', label: 'Switch child', icon: '🧒' };
+        primaryCta = { href: '/kids', label: 'Switch child', icon: 'kids' };
       } else {
-        primaryCta = { href: '/kids', label: 'Add child profile', icon: '➕' };
+        primaryCta = { href: '/kids', label: 'Add child profile', icon: 'profile' };
       }
       break;
     case 'generic':
     default:
-      primaryCta = { href: '/lessons/intro', label: 'Explore lessons', icon: '🧭' };
+      primaryCta = { href: '/lessons/intro', label: 'Explore lessons', icon: 'books' };
       break;
   }
 

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "eslint": "^8.49.0",
     "eslint-config-next": "^14.1.0",
     "eslint-config-prettier": "^10.1.8",
+    "eslint-plugin-local": "file:./eslint-plugin-local",
     "postcss": "^8.4.31",
     "prettier": "^3.0.3",
     "@tailwindcss/forms": "^0.5.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,6 +87,9 @@ importers:
       eslint-config-prettier:
         specifier: ^10.1.8
         version: 10.1.8(eslint@8.57.1)
+      eslint-plugin-local:
+        specifier: file:./eslint-plugin-local
+        version: file:eslint-plugin-local
       postcss:
         specifier: ^8.4.31
         version: 8.5.6
@@ -934,6 +937,9 @@ packages:
     engines: {node: '>=4.0'}
     peerDependencies:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9
+
+  eslint-plugin-local@file:eslint-plugin-local:
+    resolution: {directory: eslint-plugin-local, type: directory}
 
   eslint-plugin-react-hooks@5.0.0-canary-7118f5dd7-20230705:
     resolution: {integrity: sha512-AZYbMo/NW9chdL7vk6HQzQhT+PvTAEVqWk9ziruUoW2kAOcN5qNyelv70e0F1VNQAbvutOC9oc+xfWycI9FxDw==}
@@ -2965,8 +2971,8 @@ snapshots:
       '@typescript-eslint/parser': 8.43.0(eslint@8.57.1)(typescript@5.9.2)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.43.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.43.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.43.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.43.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.0.0-canary-7118f5dd7-20230705(eslint@8.57.1)
@@ -2989,7 +2995,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.43.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.1
@@ -3000,22 +3006,22 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.43.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.43.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.43.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.43.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.43.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.43.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.43.0(eslint@8.57.1)(typescript@5.9.2)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.43.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.43.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.43.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.43.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -3026,7 +3032,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.43.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.43.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.43.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -3062,6 +3068,8 @@ snapshots:
       object.fromentries: 2.0.8
       safe-regex-test: 1.1.0
       string.prototype.includes: 2.0.1
+
+  eslint-plugin-local@file:eslint-plugin-local: {}
 
   eslint-plugin-react-hooks@5.0.0-canary-7118f5dd7-20230705(eslint@8.57.1):
     dependencies:

--- a/tests/icons.spec.ts
+++ b/tests/icons.spec.ts
@@ -1,0 +1,12 @@
+import { test, expect } from '@playwright/test';
+
+const EMOJI_RE =
+  /[\u{1F300}-\u{1F5FF}\u{1F600}-\u{1F64F}\u{1F680}-\u{1F6FF}\u{1F700}-\u{1F77F}\u{1F780}-\u{1F7FF}\u{1F800}-\u{1F8FF}\u{1F900}-\u{1F9FF}\u{1FA70}-\u{1FAFF}\u{1FB00}-\u{1FBFF}\u{2600}-\u{26FF}\u{2700}-\u{27BF}\uFE0F]/u;
+
+test('icons render instead of emojis on landing', async ({ page }) => {
+  await page.goto('/');
+  const svgCount = await page.locator('svg').count();
+  expect(svgCount).toBeGreaterThan(0);
+  const content = await page.content();
+  expect(EMOJI_RE.test(content)).toBe(false);
+});


### PR DESCRIPTION
## Summary
- add a reusable icon registry, wrapper, and button component so SVG icons inherit the theme palette
- swap existing UI emojis for the new <Icon /> component across public and authed pages, shared UI, and footer CTA logic
- enforce the convention with a local ESLint rule and Playwright smoke test that fails if emoji characters return to the UI

## Testing
- pnpm lint
- pnpm test -- icons.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68d038cf97e08333b03c6c4a11a69d34